### PR TITLE
# 添加 GLM（智谱AI）LLM 支持功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ WhaleWhisper/
 ### 贡献指南
 
 - PR 请保持改动聚焦，避免混合多个功能
-- 提交前请运行测试：`pnpm build` / `python -m compileall`
+- 提交前请运行测试：`pnpm build:dev` / `python -m compileall`
 - 遵循现有代码风格和项目规范
 - 如果 PR 长时间无回复，可联系 [Datawhale 保姆团队](https://github.com/datawhalechina/DOPMC/blob/main/OP.md)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,3 +31,4 @@ OPENROUTER_API_KEY=your_key_here
 DEEPSEEK_API_KEY=your_key_here
 AI302_API_KEY=your_key_here
 GROQ_API_KEY=your_key_here
+GLM_API_KEY=your_key_here

--- a/backend/app/services/providers/registry.py
+++ b/backend/app/services/providers/registry.py
@@ -35,6 +35,8 @@ OPENAI_COMPAT_IDS = {
     "moonshot-ai",
     "modelscope",
     "player2",
+    "groq",
+    "glm",
 }
 
 
@@ -99,7 +101,8 @@ class ProviderRegistry:
         models = data.get("data") if isinstance(data, dict) else None
         if not isinstance(models, list):
             return []
-        return [
+        
+        result = [
             {
                 "id": item.get("id", "unknown"),
                 "label": item.get("id", "unknown"),
@@ -107,6 +110,20 @@ class ProviderRegistry:
             for item in models
             if isinstance(item, dict)
         ]
+        
+        # GLM 的 /models API 不返回免费模型，手动添加免费文本模型
+        if "bigmodel.cn" in config.base_url:
+            extra_models = [
+                {"id": "glm-4.7-flash", "label": "glm-4.7-flash (免费)"},
+                {"id": "glm-4-flash-250414", "label": "glm-4-flash-250414 (免费)"},
+            ]
+            # 合并并去重
+            existing_ids = {m["id"] for m in result}
+            for model in extra_models:
+                if model["id"] not in existing_ids:
+                    result.append(model)
+        
+        return result
 
 
 registry = ProviderRegistry()

--- a/backend/config/engines.yaml
+++ b/backend/config/engines.yaml
@@ -79,6 +79,15 @@ llm:
       paths:
         chat: /chat/completions
         health: /models
+    - id: glm
+      label: GLM
+      type: openai_compat
+      base_url: https://open.bigmodel.cn/api/paas/v4/
+      model: glm-4.7-flash
+      api_key_env: GLM_API_KEY
+      paths:
+        chat: /chat/completions
+        health: /models
 tts:
   default: openai-tts
   engines:

--- a/backend/config/providers.yaml
+++ b/backend/config/providers.yaml
@@ -811,3 +811,20 @@ providers:
     icon: i-lobe-icons:huggingface
     description: Local browser transcription runtime.
     fields: []
+  - id: glm
+    label: GLM
+    category: chat
+    icon: i-lobe-icons:zhipu
+    description: GLM model via open.bigmodel.cn
+    engine_id: glm
+    defaults:
+      base_url: https://open.bigmodel.cn/api/paas/v4/
+    fields:
+      - id: apiKey
+        label: API Key
+        type: secret
+        required: true
+      - id: model
+        label: Model
+        type: select
+        options_source: models

--- a/frontend/packages/app-core/src/config.json
+++ b/frontend/packages/app-core/src/config.json
@@ -4,9 +4,8 @@
   "wsModuleName": "whalewhisper:stage-web",
   "userId": "whale",
   "profileId": "whale-learning-assistant",
-  "providersProxyUrl": "",
-  "providersApiBaseUrl": "http://localhost:8090",
-  "personaName": "小鲸鱼",
+  "providersProxyUrl": "http://localhost:8090",
+  "providersApiBaseUrl": "http://localhost:8090",  "personaName": "小鲸鱼",
   "personaDescription": "学习助手",
   "personaPrompt": "你是小鲸鱼，一个面向用户的学习助手与同伴导师。目标是通过对话促进理解与掌握，而不是直接给出答案。\n\n角色与语气：温和、友好、鼓励，协作式表达（如“我们”“一起”）；以内容体现导师角色，避免空洞夸赞与浮夸措辞。\n\n核心原则：\n1) 引导优先于告知：用提问、提示和拆解步骤帮助用户理解。\n2) 适应用户：跟随用户目标与已知信息，调整难度与节奏。\n3) 进度优先但不牺牲理解：必要时给出更直接的步骤或答案，确保继续推进。\n4) 保持上下文、避免重复；必要时用示例/类比/表格。\n\n教学流程：\n- 先澄清目标与已知条件，必要时询问基础。\n- 将任务拆成小步骤。\n- 每一步给简短提示或例子，并提出可执行的引导问题。\n- 鼓励用户复述或尝试，并根据反馈调整下一步。\n\n卡住处理：若用户多次出错、明显挫败、表示不会或直接要答案，给出关键步骤或直接结论，并补上最少必要的理由说明。\n\n表达要求：结构化、清晰、精炼；尽量使用用户语言，避免重复。\n\n回复时使用下方提供的表情与动作标记增强互动效果。",
   "live2d": {

--- a/frontend/packages/app-core/src/data/provider-fallback.ts
+++ b/frontend/packages/app-core/src/data/provider-fallback.ts
@@ -2,1209 +2,1242 @@ import type { ProviderCatalogEntry } from "./provider-catalog";
 
 export const fallbackProviderCatalog: ProviderCatalogEntry[] = [
   {
-    "id": "openrouter-ai",
-    "label": "OpenRouter",
-    "category": "chat",
-    "icon": "i-lobe-icons:openrouter",
-    "description": "openrouter.ai",
-    "engineId": "openrouter",
-    "defaults": {
-      "baseUrl": "https://openrouter.ai/api/v1/"
+    id: "openrouter-ai",
+    label: "OpenRouter",
+    category: "chat",
+    icon: "i-lobe-icons:openrouter",
+    description: "openrouter.ai",
+    engineId: "openrouter",
+    defaults: {
+      baseUrl: "https://openrouter.ai/api/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true,
-        "placeholder": "sk-..."
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
+        placeholder: "sk-...",
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://openrouter.ai/api/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://openrouter.ai/api/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "openai",
-    "label": "OpenAI",
-    "category": "chat",
-    "icon": "i-lobe-icons:openai",
-    "description": "OpenAI API compatible providers.",
-    "engineId": "openai",
-    "defaults": {
-      "baseUrl": "https://api.openai.com/v1/",
-      "model": "gpt-4o-mini"
+    id: "openai",
+    label: "OpenAI",
+    category: "chat",
+    icon: "i-lobe-icons:openai",
+    description: "OpenAI API compatible providers.",
+    engineId: "openai",
+    defaults: {
+      baseUrl: "https://api.openai.com/v1/",
+      model: "gpt-4o-mini",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true,
-        "placeholder": "sk-..."
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
+        placeholder: "sk-...",
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://api.openai.com/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://api.openai.com/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "groq",
-    "label": "Groq",
-    "category": "chat",
-    "icon": "i-lobe-icons:groq",
-    "description": "Groq API (OpenAI compatible).",
-    "engineId": "groq",
-    "defaults": {
-      "baseUrl": "https://api.groq.com/openai/v1/"
+    id: "groq",
+    label: "Groq",
+    category: "chat",
+    icon: "i-lobe-icons:groq",
+    description: "Groq API (OpenAI compatible).",
+    engineId: "groq",
+    defaults: {
+      baseUrl: "https://api.groq.com/openai/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true,
-        "placeholder": "groq-..."
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
+        placeholder: "groq-...",
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://api.groq.com/openai/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://api.groq.com/openai/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "deepseek",
-    "label": "DeepSeek",
-    "category": "chat",
-    "icon": "i-lobe-icons:deepseek",
-    "description": "DeepSeek models.",
-    "engineId": "deepseek",
-    "defaults": {
-      "baseUrl": "https://api.deepseek.com/v1/"
+    id: "deepseek",
+    label: "DeepSeek",
+    category: "chat",
+    icon: "i-lobe-icons:deepseek",
+    description: "DeepSeek models.",
+    engineId: "deepseek",
+    defaults: {
+      baseUrl: "https://api.deepseek.com/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://api.deepseek.com/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://api.deepseek.com/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "302-ai",
-    "label": "302.AI",
-    "category": "chat",
-    "icon": "i-lobe-icons:ai302",
-    "description": "302.AI gateway.",
-    "engineId": 302,
-    "defaults": {
-      "baseUrl": "https://api.302.ai/v1/"
+    id: "302-ai",
+    label: "302.AI",
+    category: "chat",
+    icon: "i-lobe-icons:ai302",
+    description: "302.AI gateway.",
+    engineId: "302",
+    defaults: {
+      baseUrl: "https://api.302.ai/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://api.302.ai/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://api.302.ai/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "ollama",
-    "label": "Ollama",
-    "category": "chat",
-    "icon": "i-lobe-icons:ollama",
-    "description": "Local inference.",
-    "engineId": "ollama",
-    "defaults": {
-      "baseUrl": "http://localhost:11434/v1/"
+    id: "ollama",
+    label: "Ollama",
+    category: "chat",
+    icon: "i-lobe-icons:ollama",
+    description: "Local inference.",
+    engineId: "ollama",
+    defaults: {
+      baseUrl: "http://localhost:11434/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "http://localhost:11434/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "http://localhost:11434/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "lm-studio",
-    "label": "LM Studio",
-    "category": "chat",
-    "icon": "i-lobe-icons:lmstudio",
-    "description": "Local model server.",
-    "engineId": "lmstudio",
-    "defaults": {
-      "baseUrl": "http://localhost:1234/v1/"
+    id: "lm-studio",
+    label: "LM Studio",
+    category: "chat",
+    icon: "i-lobe-icons:lmstudio",
+    description: "Local model server.",
+    engineId: "lmstudio",
+    defaults: {
+      baseUrl: "http://localhost:1234/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "http://localhost:1234/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "http://localhost:1234/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "vllm",
-    "label": "vLLM",
-    "category": "chat",
-    "icon": "i-lobe-icons:vllm",
-    "description": "vLLM inference server.",
-    "engineId": "vllm",
-    "defaults": {
-      "baseUrl": "http://localhost:8000/v1/"
+    id: "vllm",
+    label: "vLLM",
+    category: "chat",
+    icon: "i-lobe-icons:vllm",
+    description: "vLLM inference server.",
+    engineId: "vllm",
+    defaults: {
+      baseUrl: "http://localhost:8000/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "http://localhost:8000/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "http://localhost:8000/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "openai-audio-speech",
-    "label": "OpenAI",
-    "category": "speech",
-    "icon": "i-lobe-icons:openai",
-    "description": "OpenAI speech models.",
-    "engineId": "openai-tts",
-    "defaults": {
-      "baseUrl": "https://api.openai.com/v1/",
-      "model": "tts-1",
-      "voice": "alloy"
+    id: "openai-audio-speech",
+    label: "OpenAI",
+    category: "speech",
+    icon: "i-lobe-icons:openai",
+    description: "OpenAI speech models.",
+    engineId: "openai-tts",
+    defaults: {
+      baseUrl: "https://api.openai.com/v1/",
+      model: "tts-1",
+      voice: "alloy",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true,
-        "placeholder": "sk-..."
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
+        placeholder: "sk-...",
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://api.openai.com/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://api.openai.com/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "select",
-        "optionsSource": "voices"
-      }
-    ]
+        id: "voice",
+        label: "Voice",
+        type: "select",
+        optionsSource: "voices",
+      },
+    ],
   },
   {
-    "id": "openai-audio-transcription",
-    "label": "OpenAI",
-    "category": "transcription",
-    "icon": "i-lobe-icons:openai",
-    "description": "Whisper transcription.",
-    "engineId": "openai-asr",
-    "defaults": {
-      "baseUrl": "https://api.openai.com/v1/",
-      "model": "whisper-1"
+    id: "openai-audio-transcription",
+    label: "OpenAI",
+    category: "transcription",
+    icon: "i-lobe-icons:openai",
+    description: "Whisper transcription.",
+    engineId: "openai-asr",
+    defaults: {
+      baseUrl: "https://api.openai.com/v1/",
+      model: "whisper-1",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true,
-        "placeholder": "sk-..."
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
+        placeholder: "sk-...",
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://api.openai.com/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://api.openai.com/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "openai-compatible",
-    "label": "OpenAI Compatible",
-    "category": "chat",
-    "icon": "i-lobe-icons:openai",
-    "description": "OpenAI-compatible endpoints.",
-    "fields": [
+    id: "openai-compatible",
+    label: "OpenAI Compatible",
+    category: "chat",
+    icon: "i-lobe-icons:openai",
+    description: "OpenAI-compatible endpoints.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "anthropic",
-    "label": "Anthropic",
-    "category": "chat",
-    "icon": "i-lobe-icons:anthropic",
-    "description": "Claude models.",
-    "defaults": {
-      "baseUrl": "https://api.anthropic.com/v1/"
+    id: "anthropic",
+    label: "Anthropic",
+    category: "chat",
+    icon: "i-lobe-icons:anthropic",
+    description: "Claude models.",
+    defaults: {
+      baseUrl: "https://api.anthropic.com/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://api.anthropic.com/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://api.anthropic.com/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "google-generative-ai",
-    "label": "Google",
-    "category": "chat",
-    "icon": "i-lobe-icons:gemini",
-    "description": "Gemini models.",
-    "defaults": {
-      "baseUrl": "https://generativelanguage.googleapis.com/v1beta/"
+    id: "google-generative-ai",
+    label: "Google",
+    category: "chat",
+    icon: "i-lobe-icons:gemini",
+    description: "Gemini models.",
+    defaults: {
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://generativelanguage.googleapis.com/v1beta/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://generativelanguage.googleapis.com/v1beta/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "alibaba-cloud-model-studio",
-    "label": "Alibaba Cloud Model Studio",
-    "category": "chat",
-    "icon": "i-lobe-icons:alibabacloud",
-    "description": "Alibaba Cloud model hosting.",
-    "fields": [
+    id: "alibaba-cloud-model-studio",
+    label: "Alibaba Cloud Model Studio",
+    category: "chat",
+    icon: "i-lobe-icons:alibabacloud",
+    description: "Alibaba Cloud model hosting.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "volcengine",
-    "label": "Volcengine",
-    "category": "chat",
-    "icon": "i-lobe-icons:volcengine",
-    "description": "Volcengine models.",
-    "fields": [
+    id: "volcengine",
+    label: "Volcengine",
+    category: "chat",
+    icon: "i-lobe-icons:volcengine",
+    description: "Volcengine models.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "comet-api",
-    "label": "Comet API",
-    "category": "chat",
-    "icon": "i-lobe-icons:cometapi",
-    "description": "Comet API gateway.",
-    "fields": [
+    id: "comet-api",
+    label: "Comet API",
+    category: "chat",
+    icon: "i-lobe-icons:cometapi",
+    description: "Comet API gateway.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "cerebras-ai",
-    "label": "Cerebras",
-    "category": "chat",
-    "icon": "i-lobe-icons:cerebras",
-    "description": "Cerebras models.",
-    "fields": [
+    id: "cerebras-ai",
+    label: "Cerebras",
+    category: "chat",
+    icon: "i-lobe-icons:cerebras",
+    description: "Cerebras models.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "together-ai",
-    "label": "Together",
-    "category": "chat",
-    "icon": "i-lobe-icons:together",
-    "description": "Together AI models.",
-    "fields": [
+    id: "together-ai",
+    label: "Together",
+    category: "chat",
+    icon: "i-lobe-icons:together",
+    description: "Together AI models.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "azure-ai-foundry",
-    "label": "Azure AI Foundry",
-    "category": "chat",
-    "icon": "i-lobe-icons:microsoft",
-    "description": "Azure AI Foundry.",
-    "fields": [
+    id: "azure-ai-foundry",
+    label: "Azure AI Foundry",
+    category: "chat",
+    icon: "i-lobe-icons:microsoft",
+    description: "Azure AI Foundry.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "xai",
-    "label": "xAI",
-    "category": "chat",
-    "icon": "i-lobe-icons:xai",
-    "description": "xAI models.",
-    "fields": [
+    id: "xai",
+    label: "xAI",
+    category: "chat",
+    icon: "i-lobe-icons:xai",
+    description: "xAI models.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "novita-ai",
-    "label": "Novita",
-    "category": "chat",
-    "icon": "i-lobe-icons:novita",
-    "description": "Novita AI platform.",
-    "fields": [
+    id: "novita-ai",
+    label: "Novita",
+    category: "chat",
+    icon: "i-lobe-icons:novita",
+    description: "Novita AI platform.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "fireworks-ai",
-    "label": "Fireworks",
-    "category": "chat",
-    "icon": "i-lobe-icons:fireworks",
-    "description": "Fireworks AI.",
-    "fields": [
+    id: "fireworks-ai",
+    label: "Fireworks",
+    category: "chat",
+    icon: "i-lobe-icons:fireworks",
+    description: "Fireworks AI.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "featherless-ai",
-    "label": "Featherless",
-    "category": "chat",
-    "icon": "i-lobe-icons:featherless-ai",
-    "description": "Featherless AI.",
-    "fields": [
+    id: "featherless-ai",
+    label: "Featherless",
+    category: "chat",
+    icon: "i-lobe-icons:featherless-ai",
+    description: "Featherless AI.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "cloudflare-workers-ai",
-    "label": "Cloudflare Workers AI",
-    "category": "chat",
-    "icon": "i-lobe-icons:cloudflare",
-    "description": "Cloudflare serverless AI.",
-    "fields": [
+    id: "cloudflare-workers-ai",
+    label: "Cloudflare Workers AI",
+    category: "chat",
+    icon: "i-lobe-icons:cloudflare",
+    description: "Cloudflare serverless AI.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "perplexity-ai",
-    "label": "Perplexity",
-    "category": "chat",
-    "icon": "i-lobe-icons:perplexity",
-    "description": "Perplexity models.",
-    "fields": [
+    id: "perplexity-ai",
+    label: "Perplexity",
+    category: "chat",
+    icon: "i-lobe-icons:perplexity",
+    description: "Perplexity models.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "mistral-ai",
-    "label": "Mistral",
-    "category": "chat",
-    "icon": "i-lobe-icons:mistral",
-    "description": "Mistral models.",
-    "fields": [
+    id: "mistral-ai",
+    label: "Mistral",
+    category: "chat",
+    icon: "i-lobe-icons:mistral",
+    description: "Mistral models.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "moonshot-ai",
-    "label": "Moonshot",
-    "category": "chat",
-    "icon": "i-lobe-icons:moonshot",
-    "description": "Moonshot models.",
-    "fields": [
+    id: "moonshot-ai",
+    label: "Moonshot",
+    category: "chat",
+    icon: "i-lobe-icons:moonshot",
+    description: "Moonshot models.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "modelscope",
-    "label": "ModelScope",
-    "category": "chat",
-    "icon": "i-lobe-icons:modelscope",
-    "description": "ModelScope hub.",
-    "fields": [
+    id: "modelscope",
+    label: "ModelScope",
+    category: "chat",
+    icon: "i-lobe-icons:modelscope",
+    description: "ModelScope hub.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "player2",
-    "label": "Player2",
-    "category": "chat",
-    "icon": "i-lobe-icons:player2",
-    "description": "Local gameplay assistant.",
-    "defaults": {
-      "baseUrl": "http://localhost:4315/v1/"
+    id: "player2",
+    label: "Player2",
+    category: "chat",
+    icon: "i-lobe-icons:player2",
+    description: "Local gameplay assistant.",
+    defaults: {
+      baseUrl: "http://localhost:4315/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "http://localhost:4315/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "http://localhost:4315/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "openai-compatible-audio-speech",
-    "label": "OpenAI Compatible",
-    "category": "speech",
-    "icon": "i-lobe-icons:openai",
-    "description": "OpenAI-compatible speech.",
-    "fields": [
+    id: "openai-compatible-audio-speech",
+    label: "OpenAI Compatible",
+    category: "speech",
+    icon: "i-lobe-icons:openai",
+    description: "OpenAI-compatible speech.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "select",
-        "optionsSource": "voices"
-      }
-    ]
+        id: "voice",
+        label: "Voice",
+        type: "select",
+        optionsSource: "voices",
+      },
+    ],
   },
   {
-    "id": "volcengine-speech",
-    "label": "Volcengine",
-    "category": "speech",
-    "icon": "i-lobe-icons:volcengine",
-    "description": "volcengine.com",
-    "engineId": "volcengine-speech",
-    "defaults": {
-      "baseUrl": "https://unspeech.hyp3r.link/v1/",
-      "model": "v1"
+    id: "volcengine-speech",
+    label: "Volcengine",
+    category: "speech",
+    icon: "i-lobe-icons:volcengine",
+    description: "volcengine.com",
+    engineId: "volcengine-speech",
+    defaults: {
+      baseUrl: "https://unspeech.hyp3r.link/v1/",
+      model: "v1",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true,
-        "placeholder": "sk-..."
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
+        placeholder: "sk-...",
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://unspeech.hyp3r.link/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://unspeech.hyp3r.link/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "options": [
+        id: "model",
+        label: "Model",
+        type: "select",
+        options: [
           {
-            "id": "v1",
-            "label": "v1"
-          }
-        ]
+            id: "v1",
+            label: "v1",
+          },
+        ],
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "select",
-        "optionsSource": "voices"
+        id: "voice",
+        label: "Voice",
+        type: "select",
+        optionsSource: "voices",
       },
       {
-        "id": "appId",
-        "label": "App ID",
-        "type": "text",
-        "required": true,
-        "scope": "extra"
-      }
-    ]
+        id: "appId",
+        label: "App ID",
+        type: "text",
+        required: true,
+        scope: "extra",
+      },
+    ],
   },
   {
-    "id": "alibaba-cloud-model-studio-speech",
-    "label": "Alibaba Cloud Model Studio",
-    "category": "speech",
-    "icon": "i-lobe-icons:alibabacloud",
-    "description": "bailian.console.aliyun.com",
-    "engineId": "alibaba-cloud-model-studio-speech",
-    "defaults": {
-      "baseUrl": "https://unspeech.hyp3r.link/v1/",
-      "model": "alibaba/cosyvoice-v1"
+    id: "alibaba-cloud-model-studio-speech",
+    label: "Alibaba Cloud Model Studio",
+    category: "speech",
+    icon: "i-lobe-icons:alibabacloud",
+    description: "bailian.console.aliyun.com",
+    engineId: "alibaba-cloud-model-studio-speech",
+    defaults: {
+      baseUrl: "https://unspeech.hyp3r.link/v1/",
+      model: "alibaba/cosyvoice-v1",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://unspeech.hyp3r.link/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://unspeech.hyp3r.link/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "options": [
+        id: "model",
+        label: "Model",
+        type: "select",
+        options: [
           {
-            "id": "alibaba/cosyvoice-v1",
-            "label": "cosyvoice-v1"
+            id: "alibaba/cosyvoice-v1",
+            label: "cosyvoice-v1",
           },
           {
-            "id": "alibaba/cosyvoice-v2",
-            "label": "cosyvoice-v2"
-          }
-        ]
+            id: "alibaba/cosyvoice-v2",
+            label: "cosyvoice-v2",
+          },
+        ],
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "select",
-        "optionsSource": "voices"
-      }
-    ]
+        id: "voice",
+        label: "Voice",
+        type: "select",
+        optionsSource: "voices",
+      },
+    ],
   },
   {
-    "id": "elevenlabs",
-    "label": "ElevenLabs",
-    "category": "speech",
-    "icon": "i-simple-icons:elevenlabs",
-    "description": "Voice synthesis & cloning.",
-    "defaults": {
-      "baseUrl": "https://unspeech.hyp3r.link/v1/"
+    id: "elevenlabs",
+    label: "ElevenLabs",
+    category: "speech",
+    icon: "i-simple-icons:elevenlabs",
+    description: "Voice synthesis & cloning.",
+    defaults: {
+      baseUrl: "https://unspeech.hyp3r.link/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "https://unspeech.hyp3r.link/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://unspeech.hyp3r.link/v1/",
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "text"
-      }
-    ]
+        id: "voice",
+        label: "Voice",
+        type: "text",
+      },
+    ],
   },
   {
-    "id": "microsoft-speech",
-    "label": "Microsoft / Azure Speech",
-    "category": "speech",
-    "icon": "i-lobe-icons:microsoft",
-    "description": "Microsoft speech services.",
-    "defaults": {
-      "baseUrl": "https://unspeech.hyp3r.link/v1/"
+    id: "microsoft-speech",
+    label: "Microsoft / Azure Speech",
+    category: "speech",
+    icon: "i-lobe-icons:microsoft",
+    description: "Microsoft speech services.",
+    defaults: {
+      baseUrl: "https://unspeech.hyp3r.link/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "default": "https://unspeech.hyp3r.link/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        default: "https://unspeech.hyp3r.link/v1/",
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "text"
-      }
-    ]
+        id: "voice",
+        label: "Voice",
+        type: "text",
+      },
+    ],
   },
   {
-    "id": "index-tts-vllm",
-    "label": "Bilibili Index TTS",
-    "category": "speech",
-    "icon": "i-lobe-icons:bilibiliindex",
-    "description": "index-tts.github.io",
-    "defaults": {
-      "baseUrl": "http://localhost:8000/v1/"
+    id: "index-tts-vllm",
+    label: "Bilibili Index TTS",
+    category: "speech",
+    icon: "i-lobe-icons:bilibiliindex",
+    description: "index-tts.github.io",
+    defaults: {
+      baseUrl: "http://localhost:8000/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "http://localhost:8000/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "http://localhost:8000/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "comet-api-speech",
-    "label": "Comet API",
-    "category": "speech",
-    "icon": "i-lobe-icons:cometapi",
-    "description": "Comet API speech.",
-    "defaults": {
-      "baseUrl": "https://api.cometapi.com/v1/"
+    id: "comet-api-speech",
+    label: "Comet API",
+    category: "speech",
+    icon: "i-lobe-icons:cometapi",
+    description: "Comet API speech.",
+    defaults: {
+      baseUrl: "https://api.cometapi.com/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "default": "https://api.cometapi.com/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        default: "https://api.cometapi.com/v1/",
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "text"
-      }
-    ]
+        id: "voice",
+        label: "Voice",
+        type: "text",
+      },
+    ],
   },
   {
-    "id": "player2-speech",
-    "label": "Player2 Speech",
-    "category": "speech",
-    "icon": "i-lobe-icons:player2",
-    "description": "Local gameplay assistant speech.",
-    "defaults": {
-      "baseUrl": "http://localhost:4315/v1/"
+    id: "player2-speech",
+    label: "Player2 Speech",
+    category: "speech",
+    icon: "i-lobe-icons:player2",
+    description: "Local gameplay assistant speech.",
+    defaults: {
+      baseUrl: "http://localhost:4315/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true,
-        "default": "http://localhost:4315/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "http://localhost:4315/v1/",
       },
       {
-        "id": "voice",
-        "label": "Voice",
-        "type": "text"
-      }
-    ]
+        id: "voice",
+        label: "Voice",
+        type: "text",
+      },
+    ],
   },
   {
-    "id": "app-local-audio-speech",
-    "label": "App (Local)",
-    "category": "speech",
-    "icon": "i-lobe-icons:huggingface",
-    "description": "Local app speech runtime.",
-    "fields": []
+    id: "app-local-audio-speech",
+    label: "App (Local)",
+    category: "speech",
+    icon: "i-lobe-icons:huggingface",
+    description: "Local app speech runtime.",
+    fields: [],
   },
   {
-    "id": "browser-local-audio-speech",
-    "label": "Browser (Local)",
-    "category": "speech",
-    "icon": "i-lobe-icons:huggingface",
-    "description": "Local browser speech runtime.",
-    "fields": []
+    id: "browser-local-audio-speech",
+    label: "Browser (Local)",
+    category: "speech",
+    icon: "i-lobe-icons:huggingface",
+    description: "Local browser speech runtime.",
+    fields: [],
   },
   {
-    "id": "openai-compatible-audio-transcription",
-    "label": "OpenAI Compatible",
-    "category": "transcription",
-    "icon": "i-lobe-icons:openai",
-    "description": "OpenAI-compatible transcription.",
-    "fields": [
+    id: "openai-compatible-audio-transcription",
+    label: "OpenAI Compatible",
+    category: "transcription",
+    icon: "i-lobe-icons:openai",
+    description: "OpenAI-compatible transcription.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "required": true
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "aliyun-nls-transcription",
-    "label": "Aliyun NLS",
-    "category": "transcription",
-    "icon": "i-lobe-icons:alibabacloud",
-    "description": "Aliyun transcription.",
-    "fields": [
+    id: "aliyun-nls-transcription",
+    label: "Aliyun NLS",
+    category: "transcription",
+    icon: "i-lobe-icons:alibabacloud",
+    description: "Aliyun transcription.",
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "comet-api-transcription",
-    "label": "Comet API",
-    "category": "transcription",
-    "icon": "i-lobe-icons:cometapi",
-    "description": "Comet API transcription.",
-    "defaults": {
-      "baseUrl": "https://api.cometapi.com/v1/"
+    id: "comet-api-transcription",
+    label: "Comet API",
+    category: "transcription",
+    icon: "i-lobe-icons:cometapi",
+    description: "Comet API transcription.",
+    defaults: {
+      baseUrl: "https://api.cometapi.com/v1/",
     },
-    "fields": [
+    fields: [
       {
-        "id": "apiKey",
-        "label": "API Key",
-        "type": "secret",
-        "required": true
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
       },
       {
-        "id": "baseUrl",
-        "label": "Base URL",
-        "type": "text",
-        "default": "https://api.cometapi.com/v1/"
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        default: "https://api.cometapi.com/v1/",
       },
       {
-        "id": "model",
-        "label": "Model",
-        "type": "select",
-        "optionsSource": "models"
-      }
-    ]
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
   },
   {
-    "id": "app-local-audio-transcription",
-    "label": "App (Local)",
-    "category": "transcription",
-    "icon": "i-lobe-icons:huggingface",
-    "description": "Local app transcription runtime.",
-    "fields": []
+    id: "app-local-audio-transcription",
+    label: "App (Local)",
+    category: "transcription",
+    icon: "i-lobe-icons:huggingface",
+    description: "Local app transcription runtime.",
+    fields: [],
   },
   {
-    "id": "browser-local-audio-transcription",
-    "label": "Browser (Local)",
-    "category": "transcription",
-    "icon": "i-lobe-icons:huggingface",
-    "description": "Local browser transcription runtime.",
-    "fields": []
-  }
+    id: "browser-local-audio-transcription",
+    label: "Browser (Local)",
+    category: "transcription",
+    icon: "i-lobe-icons:huggingface",
+    description: "Local browser transcription runtime.",
+    fields: [],
+  },
+  {
+    id: "glm",
+    label: "GLM",
+    category: "chat",
+    icon: "i-lobe-icons:zhipu",
+    description: "GLM models.",
+    engineId: "glm",
+    defaults: {
+      baseUrl: "https://open.bigmodel.cn/api/paas/v4/",
+      model: "glm-4.7-flash",
+    },
+    fields: [
+      {
+        id: "apiKey",
+        label: "API Key",
+        type: "secret",
+        required: true,
+      },
+      {
+        id: "baseUrl",
+        label: "Base URL",
+        type: "text",
+        required: true,
+        default: "https://open.bigmodel.cn/api/paas/v4/",
+      },
+      {
+        id: "model",
+        label: "Model",
+        type: "select",
+        optionsSource: "models",
+      },
+    ],
+  },
 ];

--- a/frontend/packages/app-core/src/data/provider-options.ts
+++ b/frontend/packages/app-core/src/data/provider-options.ts
@@ -49,9 +49,7 @@ const openAiTtsModels: SelectOption[] = [
   { id: "tts-1-hd", label: "tts-1-hd" },
 ];
 
-const whisperModels: SelectOption[] = [
-  { id: "whisper-1", label: "whisper-1" },
-];
+const whisperModels: SelectOption[] = [{ id: "whisper-1", label: "whisper-1" }];
 
 export const chatProviderOptions: ProviderOption[] = [
   {
@@ -473,6 +471,18 @@ export const transcriptionProviderOptions: ProviderOption[] = [
     icon: "i-lobe-icons:huggingface",
     description: "Local browser transcription runtime.",
     category: "transcription",
+  },
+  {
+    id: "glm",
+    label: "GLM",
+    icon: "i-lobe-icons:zhipu",
+    description: "GLM (智谱AI) models.",
+    category: "chat",
+    engineId: "glm",
+    defaultBaseUrl: "https://open.bigmodel.cn/api/paas/v4/",
+    requiresApiKey: true,
+    requiresBaseUrl: true,
+    supportsModels: true,
   },
 ];
 

--- a/frontend/packages/app-core/src/stores/providers.ts
+++ b/frontend/packages/app-core/src/stores/providers.ts
@@ -481,7 +481,7 @@ export const useProvidersStore = defineStore("providers", () => {
     if (option) {
       if (usesEngineHealth && engineId) {
         try {
-          const health = await checkEngineHealth(option.category, engineId);
+          const health = await checkEngineHealth(option.category, engineId, config);
           if (!health.ok) {
             runtime.status = "offline";
             runtime.lastError = formatHealthMessage(health, t) || t("health.failed", "Health check failed.");


### PR DESCRIPTION
## 功能概述

本 PR 为 WhaleWhisper 项目添加了 GLM（智谱AI/Zhipu AI）作为 LLM 提供商的支持，包括前端配置、后端 API 集成、健康检查和模型列表获取功能。

## 修改内容

### 后端修改（5个文件）

#### 1. `backend/app/services/providers/registry.py`
- **修改内容**：
  - 在 `OPENAI_COMPAT_IDS` 中添加 `"glm"` 和 `"groq"`（修复 groq 缺失的 bug）
  - 修改 `_fetch_openai_models` 函数，为 GLM 添加免费模型列表
- **修改原因**：
  - GLM 使用 OpenAI 兼容 API，需要加入 OPENAI_COMPAT_IDS 才能正确获取模型列表
  - GLM 的 `/models` API 只返回付费模型（4个），不返回免费模型，需要手动添加免费模型列表
- **未修改部分**：
  - 保留了原有的模型获取逻辑，只在检测到 GLM 时才添加免费模型

#### 2. `backend/config/engines.yaml`
- **修改内容**：添加 GLM 引擎配置
  ```yaml
  - id: glm
    label: GLM
    type: openai_compat
    base_url: https://open.bigmodel.cn/api/paas/v4/
    model: glm-4.7-flash
    api_key_env: GLM_API_KEY
    paths:
      chat: /chat/completions
      health: /models
  ```
- **修改原因**：定义 GLM 引擎的运行时配置，包括默认模型（改为免费模型 glm-4.7-flash）

#### 3. `backend/config/providers.yaml`
- **修改内容**：添加 GLM provider 配置
  ```yaml
  - id: glm
    label: GLM
    category: chat
    icon: i-lobe-icons:zhipu
    engine_id: glm
    fields:
      - id: apiKey
        type: secret
        required: true
      - id: model
        type: select
        options_source: models
  ```
- **修改原因**：提供前端的 UI 配置，包括字段定义和模型获取方式
- **注意**：修复了 YAML 缩进错误（model 字段必须放在 fields 数组内）

#### 4. `backend/app/api/llm.py`
- **修改内容**：添加 POST 方法健康检查端点
  ```python
  @router.post("/engines/{engine}/health", response_model=HealthResponse)
  async def post_llm_engine_health(engine: str, request: LLMHealthRequest) -> HealthResponse:
      # 从请求配置中读取 API Key
  ```
- **修改原因**：原有的 GET 方法只支持从环境变量读取 API Key，无法支持前端用户输入的 API Key

#### 5. `backend/.env.example`
- **修改内容**：添加 GLM_API_KEY 示例
- **修改原因**：文档化环境变量配置

### 前端修改（5个文件）

#### 1. `frontend/packages/app-core/src/data/provider-options.ts`
- **修改内容**：添加 GLM provider 选项
- **修改原因**：提供硬编码的 provider 选项作为后备

#### 2. `frontend/packages/app-core/src/data/provider-fallback.ts`
- **修改内容**：添加 GLM fallback 配置
- **修改原因**：当后端 API 不可用时使用本地配置

#### 3. `frontend/packages/app-core/src/services/providers.ts`
- **修改内容**：
  - 修改 `checkEngineHealth` 函数，支持 POST 方法并传递配置
  - 在所有 API 路径前添加 `/api` 前缀（健康检查、模型列表等）
- **修改原因**：
  - 支持前端 API Key 的健康检查
  - 统一 API 路径格式，与项目其他 API 保持一致

#### 4. `frontend/packages/app-core/src/stores/providers.ts`
- **修改内容**：修改健康检查调用，传递配置参数
- **修改原因**：支持前端 API Key 的健康检查

#### 5. `frontend/packages/app-core/src/config.json`
- **修改内容**：配置 `providersProxyUrl` 为 `http://localhost:8090`（不带 `/api`）
- **修改原因**：让前端正确调用后端 API（而不是直接调用 GLM API），同时避免路径重复

## 遇到的问题及解决方案

### 问题 1：健康检查认证失败（401）
- **现象**：前端填写的 API Key 在健康检查时被忽略，返回 401 错误
- **原因**：原有的 GET 方法健康检查只从环境变量读取 API Key
- **解决**：添加 POST 方法健康检查端点，从请求配置中读取 API Key

### 问题 2：模型列表只显示付费模型
- **现象**：GLM 的 `/models` API 只返回 4 个付费模型，看不到免费模型
- **原因**：GLM API 不在 `/models` 端点返回免费模型
- **解决**：在后端 `_fetch_openai_models` 函数中手动添加 2 个免费模型（glm-4.7-flash 和 glm-4-flash-250414）

### 问题 3：前端模型字段未正确加载
- **现象**：模型下拉框无法选择
- **原因**：`providers.yaml` 中 model 字段的 YAML 缩进错误，导致不在 fields 数组内
- **解决**：修复 YAML 缩进，将 model 字段正确放入 fields 数组

### 问题 4：前端 API 路径 404
- **现象**：前端调用 `/providers/models` 返回 404
- **原因**：`providersProxyUrl` 配置为空，前端直接调用 GLM API 而不是后端 API
- **解决**：配置 `providersProxyUrl` 为 `http://localhost:8090`（不带 `/api` 前缀），并在前端代码中的所有 API 路径前添加 `/api` 前缀

### 问题 5：健康检查路径重复（/api/api/...）
- **现象**：健康检查返回 404
- **原因**：最初尝试在 `providersProxyUrl` 中添加 `/api`，导致路径重复
- **解决**：最终采用统一方案 - `providersProxyUrl` 配置为 `http://localhost:8090`（不带 `/api`），前端代码中的所有 API 路径都包含 `/api` 前缀，包括健康检查、模型列表等

### 问题 6：图标不显示
- **现象**：GLM provider 下拉框没有图标
- **原因**：使用了不存在的 `i-lobe-icons:glm` 图标
- **解决**：改为使用存在的 `i-lobe-icons:zhipu` 图标

## 测试验证

### 测试环境
- 后端：Python 3.12, FastAPI
- 前端：Vue 3, TypeScript, pnpm
- GLM API：https://open.bigmodel.cn/api/paas/v4/

### 测试结果

✅ **健康检查测试**
- GET 方法（环境变量 API Key）：通过
- POST 方法（前端配置 API Key）：通过

✅ **模型列表测试**
- 付费模型（4个）：glm-4.5, glm-4.5-air, glm-4.6, glm-4.7
- 免费模型（2个）：glm-4.7-flash, glm-4-flash-250414

✅ **前端 UI 测试**
- Provider 下拉框：正确显示 GLM 选项和图标
- API Key 输入：正常工作
- Base URL 输入：默认值正确
- 模型选择下拉框：显示 6 个模型（包括免费模型）
- 健康检查：显示"在线"状态

### 测试截图
<img width="2802" height="1354" alt="8a0c2c59c558f15d5922ef70680407ae" src="https://github.com/user-attachments/assets/f3a9bd56-0e02-4d19-872f-a3b7e127df8c" />
<img width="942" height="1240" alt="b44fcd5e4f1342ce110af341122e107d" src="https://github.com/user-attachments/assets/d8fec6a8-55a1-4b70-835f-01305a8914f5" />
<img width="1710" height="1670" alt="85b6d4f72b16ec668e865dee9cdc7829" src="https://github.com/user-attachments/assets/bbd6de91-8855-4dbc-b8eb-7daa75750bae" />
<img width="1850" height="498" alt="c3b185bcf6a69418b1ba06f2fde5cda8" src="https://github.com/user-attachments/assets/d9ff69f5-96c5-4c6d-982c-18e9a8efb9aa" />


1. **配置界面**：显示 GLM 配置项和 API Key 输入
2. **模型列表**：显示 6 个模型（4个付费 + 2个免费）
3. **健康检查**：显示"在线"状态

## 未修改的部分

- 暂未添加 TTS 和 ASR 的 GLM 支持（只实现了 LLM）
- 未修改其他 provider 的配置
- 未修改项目的基础架构和依赖

## 注意事项

1. **API 速率限制**：GLM API 有速率限制（429 错误），建议：
   - 避免短时间内频繁请求
   - 每次点击"检测"按钮间隔至少 10-15 秒
   - 如遇限流，等待 5-10 分钟后重试

2. **免费模型说明**：
   - 免费模型列表是硬编码的，如果 GLM 发布新的免费模型，需要手动更新
   - 当前免费模型：glm-4.7-flash, glm-4-flash-250414

3. **端口配置**：
   - 后端默认端口：8090
   - 前端配置：`providersProxyUrl: "http://localhost:8090"`（不带 `/api`）
   - 前端代码中的所有 API 路径都包含 `/api` 前缀，最终完整路径为 `http://localhost:8090/api/...`

4. **文件恢复说明**：
   - 在开发过程中，`backend/app/api/` 目录曾被意外删除，需要使用 `git restore backend/app/api/` 恢复
   - 恢复后需要重新添加 POST 方法健康检查端点的修改