### PR TITLE
fix: use env vars instead of secrets in step-level if conditions

### DIFF
--- a/.github/workflows/claude-issue-duplicate-check.yml
+++ b/.github/workflows/claude-issue-duplicate-check.yml
@@ -16,20 +16,22 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
 
     steps:
       - name: Skip (missing ANTHROPIC_API_KEY)
-        if: ${{ secrets.ANTHROPIC_API_KEY == '' }}
+        if: env.HAS_ANTHROPIC_KEY != 'true'
         run: echo "ANTHROPIC_API_KEY is not configured; skipping duplicate check."
 
       - name: Checkout repository
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: env.HAS_ANTHROPIC_KEY == 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Ensure duplicate label exists
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: env.HAS_ANTHROPIC_KEY == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}
@@ -55,7 +57,7 @@ jobs:
             }
 
       - name: Load prompt
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: env.HAS_ANTHROPIC_KEY == 'true'
         id: prompt
         shell: bash
         run: |
@@ -66,7 +68,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Claude duplicate check
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: env.HAS_ANTHROPIC_KEY == 'true'
         uses: anthropics/claude-code-action@v1
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/codex-issue-triage.yml
+++ b/.github/workflows/codex-issue-triage.yml
@@ -15,20 +15,22 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
 
     steps:
       - name: Skip (missing OPENAI_API_KEY)
-        if: ${{ secrets.OPENAI_API_KEY == '' }}
+        if: env.HAS_OPENAI_KEY != 'true'
         run: echo "OPENAI_API_KEY is not configured; skipping issue triage."
 
       - name: Checkout repository (for docs context)
-        if: ${{ secrets.OPENAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_KEY == 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Compute Responses API endpoint override (optional)
-        if: ${{ secrets.OPENAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_KEY == 'true'
         id: responses_endpoint
         shell: bash
         run: |
@@ -43,7 +45,7 @@ jobs:
           fi
 
       - name: Run Codex triage
-        if: ${{ secrets.OPENAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_KEY == 'true'
         id: run_codex
         uses: openai/codex-action@v1
         env:
@@ -62,7 +64,7 @@ jobs:
           prompt-file: .github/prompts/codex-issue-triage.md
 
       - name: Apply labels and upsert comment
-        if: ${{ secrets.OPENAI_API_KEY != '' && steps.run_codex.outputs.final-message != '' }}
+        if: env.HAS_OPENAI_KEY == 'true' && steps.run_codex.outputs.final-message != ''
         uses: actions/github-script@v7
         env:
           TRIAGE_JSON: ${{ steps.run_codex.outputs.final-message }}


### PR DESCRIPTION
GitHub Actions does not support `secrets` context in step-level `if` expressions. Move secret checks to job-level `env` variables and reference them via `env.*` in step conditions.

Affected workflows:
- claude-issue-duplicate-check.yml
- codex-issue-triage.yml

## 变更说明

<!-- 简要说明这次 PR 做了什么、为什么做 -->

## 关联 Issue / 需求

<!-- 填写 #123 或链接；没有可写 N/A -->

## 自测方式

- [ ] 后端：`cd backend && uv run uvicorn app.main:app --reload --port 8090`
- [ ] 前端：`cd frontend && pnpm --filter @whalewhisper/web dev`

## 风险 & 回滚

<!-- 是否影响配置/协议/数据？如何回滚？ -->

## Checklist

- [ ] 已保证改动聚焦（不混杂无关重构）
- [ ] 已更新相关文档（如 README / 配置示例）
- [ ] 未提交任何密钥/个人信息
- [ ] CI（`PR Checks`）通过

<!-- codex-pr-description:start -->

## 📝 PR 说明（Codex 自动生成）

- **变更概览**：调整 Issue 自动化工作流的“是否配置 API Key”判断方式：在 job 级别新增 `HAS_ANTHROPIC_KEY` / `HAS_OPENAI_KEY` 环境变量，并用它统一控制后续 steps 执行。涉及 `.github/workflows/claude-issue-duplicate-check.yml` 与 `.github/workflows/codex-issue-triage.yml`（共 2 个文件，14+/10-）。
- **影响范围**：ci
- **如何验证**：
  1) 不配置（或移除）仓库 Secrets：`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`，新建一个 issue，确认对应 workflow 运行后只执行 `Skip (missing …)` step，后续 steps 均被跳过  
  2) 配置相应 Secrets 后再新建 issue，确认 workflow 会继续执行 `Checkout`、以及 Claude/Codex 对应的 action steps；同时 `codex-issue-triage` 仅在 `final-message` 非空时才会进入 “Apply labels and upsert comment”
- **风险点**：条件判断改为对 env 字符串 `'true'` 的比较；若 GitHub Actions 对布尔表达式写入 env 的字符串表现变化，可能导致 steps 误跳过/误执行（仅影响 CI 工作流）

<!-- codex-pr-description:end -->
