### PR TITLE
chore(backend): remove unused imports (ruff F401)

### DIFF
--- a/backend/app/services/catalogs/provider_catalog.py
+++ b/backend/app/services/catalogs/provider_catalog.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 import yaml
 

--- a/backend/app/services/engines/loader.py
+++ b/backend/app/services/engines/loader.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Any, Dict, List
 

--- a/backend/app/services/providers/llm.py
+++ b/backend/app/services/providers/llm.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 

--- a/backend/tests/test_provider_voices_tts.py
+++ b/backend/tests/test_provider_voices_tts.py
@@ -8,7 +8,6 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
 import app.services.providers.registry as provider_registry_module  # noqa: E402
-from app.services.engines.runtime_store import EngineRuntimeConfig, store as runtime_store  # noqa: E402
 from app.services.providers.types import ProviderConfig  # noqa: E402
 
 


### PR DESCRIPTION
## 背景

多模型冗余代码审计（codex reviewer + ruff/pyflakes）发现后端 5 处未使用 import。

## 改动

删除以下未使用 import（ruff F401 确认，无任何引用点）：

| 文件 | 删除项 |
|------|--------|
| `services/catalogs/provider_catalog.py` | `typing.Dict` |
| `services/engines/loader.py` | `os` |
| `services/providers/llm.py` | `typing.Iterable` |
| `tests/test_provider_voices_tts.py` | `EngineRuntimeConfig`, `store as runtime_store` |

## 验证

- `ruff check --select F401 backend/app backend/tests` → All checks passed
- `pyflakes backend/app backend/tests` → 无报错

纯删除未使用 import，无行为变更。

## 关联

冗余代码审计第一批清理 PR-1/5。