### PR TITLE
refactor(backend): remove dead ASR/TTS provider stubs

### DIFF
--- a/backend/app/services/providers/asr.py
+++ b/backend/app/services/providers/asr.py
@@ -1,3 +1,0 @@
-class ASRProvider:
-    def transcribe(self, audio: bytes) -> str:
-        raise NotImplementedError

--- a/backend/app/services/providers/tts.py
+++ b/backend/app/services/providers/tts.py
@@ -1,3 +1,0 @@
-class TTSProvider:
-    def synthesize(self, text: str) -> bytes:
-        raise NotImplementedError


### PR DESCRIPTION
## 背景

多模型冗余代码审计发现 `services/providers/asr.py` 和 `tts.py` 是死代码。

dev 分支重构 TTS/ASR 流程后，真实 provider 实现已迁至 `registry.py` 和 `llm.py`，这两个仅含 `raise NotImplementedError` 的 stub 模块成为孤儿，无任何引用且未被 `providers/__init__.py` 导出。

## 改动

删除：
- `services/providers/asr.py`（`ASRProvider` 类，仅 `raise NotImplementedError`）
- `services/providers/tts.py`（`TTSProvider` 类，仅 `raise NotImplementedError`）

## 验证

- `grep -rn "ASRProvider|TTSProvider" backend/app backend/tests` → 零残留引用
- `import app.services.providers` → 包导入正常
- `providers/__init__.py` 本就未导出这两个类

纯删除死 stub，无行为变更。如未来需要 provider 接口抽象，应改为接入 registry 的 ABC/Protocol 并补测试，而非保留空 stub。

## 关联

冗余代码审计第一批清理 PR-2/5。