### PR TITLE
refactor(backend): remove unreachable model guard in asr

### DIFF
--- a/backend/app/api/asr.py
+++ b/backend/app/api/asr.py
@@ -513,8 +513,6 @@ def _resolve_aliyun_dashscope_credentials(config, overrides: Dict[str, Any]) -> 
         raise HTTPException(status_code=400, detail="Alibaba Bailian ASR missing apiKey")
 
     model = ALIYUN_ASR_REALTIME_MODEL
-    if not model:
-        raise HTTPException(status_code=400, detail="Alibaba Bailian ASR missing model")
 
     return {
         "params": params,


### PR DESCRIPTION
## 背景

多模型冗余代码审计发现 `api/asr.py:515-517` 存在永假防御分支。

```python
ALIYUN_ASR_REALTIME_MODEL = "qwen3-asr-flash-realtime"  # 非空常量
...
model = ALIYUN_ASR_REALTIME_MODEL
if not model:                                            # 永远为 False
    raise HTTPException(400, "Alibaba Bailian ASR missing model")
```

`model` 赋值自非空字符串常量，`if not model` 永不触发，是死代码。

## 改动

删除 `if not model: raise ...` 两行。保留 `model = ALIYUN_ASR_REALTIME_MODEL` 赋值，因为后续 `return` 字典用到 `"model": model`。

> 注：审计同时检查了 `api/tts.py` 的三处 `if not model`（286/383/688 行），它们检查的是 `_resolve_tts_model()` 的动态返回值（可能为空），属合法运行时校验，**不在本次删除范围**。

## 验证

- `python -m py_compile backend/app/api/asr.py` → 通过
- `ruff check --select F811,F821 backend/app/api/asr.py` → All checks passed

无行为变更（删除的是不可达分支）。

## 关联

冗余代码审计第一批清理 PR-4/5。