### PR TITLE
refactor(backend): remove unreachable provider branches in tts payload

### DIFF
--- a/backend/app/api/tts.py
+++ b/backend/app/api/tts.py
@@ -348,31 +348,6 @@ def _build_volcengine_extra_body(overrides: Dict[str, Any]) -> Dict[str, Any]:
     return extra_body
 
 
-def _build_alibaba_extra_body(overrides: Dict[str, Any]) -> Dict[str, Any]:
-    extra_body = {
-        **_read_map(overrides, "extraBody"),
-        **_read_map(overrides, "extra_body"),
-    }
-
-    rate = _read_number(overrides, "rate")
-    if rate is not None:
-        extra_body["rate"] = rate
-
-    pitch = _read_number(overrides, "pitch")
-    if pitch is not None:
-        extra_body["pitch"] = pitch
-
-    volume = _read_number(overrides, "volume")
-    if volume is not None:
-        extra_body["volume"] = volume
-
-    sample_rate = _read_number(overrides, "sample_rate", "sampleRate")
-    if sample_rate is not None:
-        extra_body["sample_rate"] = int(sample_rate)
-
-    return extra_body
-
-
 def _build_unspeech_payload(
     engine_id: str,
     runtime_config,
@@ -404,13 +379,6 @@ def _build_unspeech_payload(
     speed = _read_number(overrides, "speed")
     if speed is not None:
         payload["speed"] = speed
-
-    if engine_id in VOLCENGINE_ENGINE_IDS:
-        payload["extra_body"] = _build_volcengine_extra_body(overrides)
-    elif engine_id in ALIBABA_ENGINE_IDS:
-        extra_body = _build_alibaba_extra_body(overrides)
-        if extra_body:
-            payload["extra_body"] = extra_body
 
     return payload
 

--- a/backend/tests/test_tts_engine_relay.py
+++ b/backend/tests/test_tts_engine_relay.py
@@ -58,58 +58,34 @@ def test_resolve_tts_api_key_prefers_request_override():
             os.environ["TEST_TTS_KEY"] = previous
 
 
-def test_build_unspeech_payload_for_volcengine():
+def test_build_unspeech_payload_generic_path():
+    """_build_unspeech_payload only runs for non-volcengine/non-alibaba engines
+    (run_tts_engine returns early for those), so exercise the generic payload
+    path with a neutral engine id and assert no provider-specific extra_body."""
     runtime = EngineRuntimeConfig(
-        id="volcengine-speech",
+        id="unspeech-generic",
         base_url="https://unspeech.example/v1",
         model="v1",
     )
 
     payload = _build_unspeech_payload(
-        engine_id="volcengine-speech",
+        engine_id="unspeech-generic",
         runtime_config=runtime,
-        text="hello volcengine",
+        text="hello generic",
         overrides={
             "model": "v1",
             "voice": "zh_female_sample",
-            "appId": "appid-123",
             "response_format": "mp3",
+            "speed": 1.2,
         },
     )
 
-    assert payload["model"] == "volcengine/v1"
+    assert payload["model"] == "v1"
     assert payload["voice"] == "zh_female_sample"
-    assert payload["input"] == "hello volcengine"
+    assert payload["input"] == "hello generic"
     assert payload["response_format"] == "mp3"
-    assert payload["extra_body"]["app"]["appid"] == "appid-123"
-
-
-def test_build_unspeech_payload_for_alibaba():
-    runtime = EngineRuntimeConfig(
-        id="alibaba-cloud-model-studio-speech",
-        base_url="https://unspeech.example/v1",
-        model="alibaba/cosyvoice-v1",
-    )
-
-    payload = _build_unspeech_payload(
-        engine_id="alibaba-cloud-model-studio-speech",
-        runtime_config=runtime,
-        text="hello alibaba",
-        overrides={
-            "model": "cosyvoice-v1",
-            "voice": "longxiaochun_v2",
-            "rate": 1.2,
-            "pitch": 0.9,
-            "volume": 80,
-        },
-    )
-
-    assert payload["model"] == "alibaba/cosyvoice-v1"
-    assert payload["voice"] == "longxiaochun_v2"
-    assert payload["input"] == "hello alibaba"
-    assert payload["extra_body"]["rate"] == 1.2
-    assert payload["extra_body"]["pitch"] == 0.9
-    assert payload["extra_body"]["volume"] == 80
+    assert payload["speed"] == 1.2
+    assert "extra_body" not in payload
 
 
 def test_build_volcengine_provider_payload_direct():
@@ -213,8 +189,7 @@ def test_decorate_tts_error_for_volcengine_grant_issue():
 if __name__ == "__main__":
     run("extract tts input supports string and object forms", test_extract_tts_input_supports_string_and_object_forms)
     run("resolve tts api key prefers request override", test_resolve_tts_api_key_prefers_request_override)
-    run("build unspeech payload for volcengine", test_build_unspeech_payload_for_volcengine)
-    run("build unspeech payload for alibaba", test_build_unspeech_payload_for_alibaba)
+    run("build unspeech payload generic path", test_build_unspeech_payload_generic_path)
     run("build volcengine provider payload direct", test_build_volcengine_provider_payload_direct)
     run(
         "resolve volcengine tts url ignores client url override",


### PR DESCRIPTION
## 背景

多模型冗余代码审计发现 `api/tts.py` 存在运行路径不可达的 provider 分支，且测试固定了这些不可达实现。

### 控制流证据

`run_tts_engine()` 的分发逻辑：
```python
if engine_id in VOLCENGINE_ENGINE_IDS:      # :90
    return await _forward_volcengine_tts(...)
if engine_id in ALIBABA_ENGINE_IDS:          # :98
    return await _forward_alibaba_tts(...)
payload = _build_unspeech_payload(...)       # :107  仅其他 engine 走到这里
```

`_build_unspeech_payload` 全后端**唯一调用点**是 `:107`，而走到 `:107` 时 engine_id 已不可能在 VOLCENGINE/ALIBABA 集合。因此其内部的 provider-specific 分支不可达：

```python
if engine_id in VOLCENGINE_ENGINE_IDS:       # 不可达
    payload["extra_body"] = _build_volcengine_extra_body(overrides)
elif engine_id in ALIBABA_ENGINE_IDS:        # 不可达
    extra_body = _build_alibaba_extra_body(overrides)
```

`_build_alibaba_extra_body` 的唯一调用就在这个不可达分支里 → 整个函数是死代码。

> `_build_volcengine_extra_body` **保留**：它在 `_build_volcengine_provider_payload`（:495，被可达的 `_forward_volcengine_tts` 调用）中仍被使用。

## 改动

**`api/tts.py`**（-32 行）
- 删除 `_build_unspeech_payload` 内 VOLCENGINE/ALIBABA extra_body 分支
- 删除无引用的 `_build_alibaba_extra_body` 函数

**`tests/test_tts_engine_relay.py`**
- 删除 `test_build_unspeech_payload_for_volcengine` / `test_build_unspeech_payload_for_alibaba`（它们直接传 volcengine/alibaba engine_id 调 `_build_unspeech_payload`，覆盖的正是生产不可达路径）
- 新增 `test_build_unspeech_payload_generic_path`：用中性 engine_id 覆盖真实通用路径（model/voice/input/response_format/speed），并断言无 `extra_body`

## 验证

- `py_compile tts.py` → OK
- `ruff check --select F401,F811,F821` → All checks passed
- `grep -rn "_build_alibaba_extra_body" backend/` → 零残留
- `python tests/test_tts_engine_relay.py` → 10/10 PASS（原 11 个，删 2 加 1）

净减 57 行，无行为变更（删除的是不可达分支）。

## 关联

冗余代码审计第一批清理 PR-5/5（最后一批零风险项）。