### PR TITLE
Revert PR #38: feat(agent) coze支持 (误合到 main)

### DIFF
--- a/backend/app/app_factory.py
+++ b/backend/app/app_factory.py
@@ -1,14 +1,10 @@
 import logging
 import time
 
-from dotenv import load_dotenv
 from fastapi import FastAPI
 
 from app.core.settings import get_settings
 from app.extensions import ext_catalogs, ext_cors, ext_engines, ext_logging
-
-# Load .env file into environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/backend/config/engines.yaml
+++ b/backend/config/engines.yaml
@@ -261,16 +261,14 @@ agent:
       paths:
         chat: /v3/chat
         conversation: /v1/conversation/create
-        health: /v1/workspaces
+        health: /health
       defaults:
         user: whale
       params:
         - name: token
           type: secret
-          description: Coze API Token (optional if set via COZE_TOKEN env)
         - name: bot_id
           type: string
-          description: Coze Bot ID
         - name: api_base
           type: string
           default: https://api.coze.cn


### PR DESCRIPTION
## 背景

PR #38「feat(agent): coze支持」误合并到 **main** 分支。该改动本应进入 **dev** 开发分支，base 分支选错。

本 PR 通过 \`git revert -m 1\` 反向撤销 PR #38 在 main 上引入的改动，保留完整历史（不改写公共历史）。

## 撤销内容

反向于 PR #38（merge commit \`287a8ac\`，内容提交 \`00fb5c7\`）：

- \`backend/app/app_factory.py\`：移除 \`load_dotenv()\` 调用及 \`from dotenv import load_dotenv\`
- \`backend/config/engines.yaml\`：恢复 coze engine 的 \`health: /health\`（原 \`/v1/workspaces\`），移除 token/bot_id 的 description 字段

## 后续

coze 改动将通过独立的 PR 正确合入 **dev** 分支（见关联 PR）。

## 验证

\`git revert -m 1 287a8ac\` 自动生成反向提交，diff 与 PR #38 精确对称（+1/-7 vs 原 +7/-1）。