### PR TITLE
feat(agent): coze支持 (正确合入 dev)

### DIFF
--- a/backend/app/app_factory.py
+++ b/backend/app/app_factory.py
@@ -1,10 +1,14 @@
 import logging
 import time
 
+from dotenv import load_dotenv
 from fastapi import FastAPI
 
 from app.core.settings import get_settings
 from app.extensions import ext_catalogs, ext_cors, ext_engines, ext_logging
+
+# Load .env file into environment variables
+load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/backend/config/engines.yaml
+++ b/backend/config/engines.yaml
@@ -285,14 +285,16 @@ agent:
       paths:
         chat: /v3/chat
         conversation: /v1/conversation/create
-        health: /health
+        health: /v1/workspaces
       defaults:
         user: whale
       params:
         - name: token
           type: secret
+          description: Coze API Token (optional if set via COZE_TOKEN env)
         - name: bot_id
           type: string
+          description: Coze Bot ID
         - name: api_base
           type: string
           default: https://api.coze.cn


### PR DESCRIPTION
## 背景

PR #38「feat(agent): coze支持」原误合并到 **main** 分支（已通过 PR #45 revert 撤回）。本 PR 将相同的 coze 改动正确合入 **dev** 开发分支。

## 改动

Cherry-pick 自 PR #38 内容提交 \`00fb5c7\`（原作者 @chaojixinren 署名保留）：

- \`backend/app/app_factory.py\`：启动时 \`load_dotenv()\` 加载 .env 到环境变量
- \`backend/config/engines.yaml\`：coze-agent engine 修正 \`health: /v1/workspaces\`，为 token/bot_id 补充 description

## 验证

- \`python -m py_compile app_factory.py\` → OK
- \`ruff check --select F401,F811 app_factory.py\` → All checks passed
- \`python-dotenv\` 已在 dev 的 \`pyproject.toml\` dependencies 中（\`core/settings.py\` 本就在使用 dotenv），无新增依赖
- \`engines.yaml\` cherry-pick 自动合并，无冲突

## 关联

- 撤回误合并：#45（Revert PR #38 on main）