### PR TITLE
feat(fastgpt): 增强 FastGPT 智能体对接 (正确合入 dev)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ backend/data/
 # IDE
 .vscode/
 airi/
+
+# Environment
+.env

--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -16,8 +16,8 @@ from app.api.engine_schemas import (
     EngineRunRequest,
     HealthResponse,
 )
-from app.services.engines import registry
-from app.services.engines import runtime_store
+from app.services.engines import registry, runtime_store
+from app.services.agents.utils import coerce_bool
 from app.services.engines.health import check_engine_health
 from app.services.agents import (
     AgentContext,
@@ -116,7 +116,7 @@ async def run_agent_engine(request: EngineRunRequest) -> StreamingResponse:
     spec = registry.get("agent", engine_id)
     handler = build_agent_handler(runtime)
     params = request.config if isinstance(request.config, dict) else {}
-    memory_bridge = _coerce_bool(params.get("memory_bridge") or params.get("memoryBridge"))
+    memory_bridge = coerce_bool(params.get("memory_bridge") or params.get("memoryBridge"))
     params = _strip_agent_config(params)
     if memory_bridge:
         scope = _extract_memory_scope(request.data)
@@ -190,16 +190,6 @@ def _extract_memory_scope(data: Any) -> MemoryScope:
 def _strip_agent_config(config: Dict[str, Any]) -> Dict[str, Any]:
     blocked = {"memory_bridge", "memoryBridge"}
     return {key: value for key, value in config.items() if key not in blocked}
-
-
-def _coerce_bool(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return False
 
 
 def _resolve_capabilities(spec) -> Dict[str, Any]:

--- a/backend/app/services/agents/handlers.py
+++ b/backend/app/services/agents/handlers.py
@@ -253,8 +253,9 @@ class FastGPTAgentHandler(AgentHandler):
         params = _apply_fastgpt_defaults(context)
         base_url = params.get("base_url")
         api_key = params.get("api_key")
-        uid = params.get("uid")
         conversation_id = params.get("conversation_id") or ""
+        variables = _coerce_fastgpt_variables(params.get("variables"))
+        detail = params.get("detail", False)
 
         if not base_url:
             yield AgentEvent(event="error", data={"message": "Missing FastGPT base URL."})
@@ -276,25 +277,32 @@ class FastGPTAgentHandler(AgentHandler):
         payload = {
             "chatId": conversation_id,
             "stream": True,
-            "detail": False,
+            "detail": bool(detail),
             "messages": [
                 {"role": "user", "content": text},
             ],
-            "customUid": uid,
         }
+        if variables:
+            payload["variables"] = variables
 
         chat_path = _resolve_path(context.runtime, "chat", "/v1/chat/completions")
         async with httpx.AsyncClient(timeout=context.runtime.timeout) as client:
-            async with client.stream(
-                "POST",
-                _build_url(base_url, chat_path),
-                headers=headers,
-                json=payload,
-            ) as response:
-                response.raise_for_status()
+            async with client.stream("POST", _build_url(base_url, chat_path), headers=headers, json=payload) as response:
+                if response.status_code >= 400:
+                    detail = await _read_error_detail(response)
+                    yield AgentEvent(event="error", data={"message": detail})
+                    return
+                current_conversation_id = conversation_id
+                current_event: Optional[str] = None
                 async for line in response.aiter_lines():
                     chunk = line.strip()
-                    if not chunk or not chunk.startswith("data:"):
+                    if not chunk:
+                        current_event = None
+                        continue
+                    if chunk.startswith("event:"):
+                        current_event = chunk.split("event:", 1)[1].strip()
+                        continue
+                    if not chunk.startswith("data:"):
                         continue
                     data_payload = chunk.split("data:", 1)[1].strip()
                     if not data_payload or data_payload == "[DONE]":
@@ -303,13 +311,31 @@ class FastGPTAgentHandler(AgentHandler):
                         data = json.loads(data_payload)
                     except json.JSONDecodeError:
                         continue
-                    try:
-                        delta = data["choices"][0].get("delta") or {}
-                        content = delta.get("content")
-                    except (KeyError, IndexError, TypeError):
-                        content = None
-                    if content:
-                        yield AgentEvent(event="message.delta", data={"text": str(content)})
+
+                    if not current_conversation_id:
+                        extracted_id = _extract_fastgpt_chat_id(data)
+                        if extracted_id:
+                            current_conversation_id = extracted_id
+                            yield AgentEvent(event="conversation.id", data={"conversation_id": extracted_id})
+
+                    event_type = current_event or "answer"
+                    if event_type in ("answer", "fastAnswer"):
+                        try:
+                            delta = data.get("choices", [{}])[0].get("delta") or {}
+                            content = delta.get("content")
+                        except (KeyError, IndexError, TypeError):
+                            content = None
+                        if content:
+                            yield AgentEvent(event="message.delta", data={"text": str(content)})
+                    elif event_type == "error":
+                        message = (
+                            data.get("message") or data.get("error") or "Unknown error"
+                        )
+                        yield AgentEvent(event="error", data={"message": str(message)})
+                    elif event_type == "interactive":
+                        yield AgentEvent(event="interactive", data={"interactive": data.get("interactive", {})})
+                    elif event_type == "flowResponses":
+                        yield AgentEvent(event="flow_responses", data={"responses": data})
 
         yield AgentEvent(event="message.done", data={})
 
@@ -593,6 +619,36 @@ def _extract_conversation_id(payload: Any) -> str:
     if isinstance(payload, str):
         return payload
     return ""
+
+
+def _extract_fastgpt_chat_id(data: Dict[str, Any]) -> Optional[str]:
+    """从 FastGPT SSE 响应中提取 chatId"""
+    for key in ("chatId", "chat_id", "conversation_id", "conversationId", "id"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    nested = data.get("data")
+    if isinstance(nested, dict):
+        for key in ("chatId", "chat_id", "conversation_id", "conversationId", "id"):
+            value = nested.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _coerce_fastgpt_variables(value: Any) -> Dict[str, Any]:
+    """解析 FastGPT variables 参数"""
+    if value is None or value == "":
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
 
 
 register_agent_handler({"dify", "dify_agent"}, DifyAgentHandler)

--- a/backend/app/services/agents/handlers.py
+++ b/backend/app/services/agents/handlers.py
@@ -9,7 +9,7 @@ import httpx
 from app.core.http_utils import normalize_path
 from app.services.engines.runtime_store import EngineRuntimeConfig
 from .types import AgentEvent
-from .utils import merge_params
+from .utils import coerce_bool, coerce_json_dict, merge_params
 
 
 @dataclass
@@ -22,7 +22,9 @@ class AgentHandler:
     async def create_conversation(self, context: AgentContext) -> str:
         return ""
 
-    async def stream(self, context: AgentContext, text: str) -> AsyncIterator[AgentEvent]:
+    async def stream(
+        self, context: AgentContext, text: str
+    ) -> AsyncIterator[AgentEvent]:
         if not text:
             return
         yield AgentEvent(event="message.delta", data={"text": text})
@@ -69,7 +71,9 @@ class DifyAgentHandler(AgentHandler):
             data = response.json()
         return str(data.get("conversation_id") or "")
 
-    async def stream(self, context: AgentContext, text: str) -> AsyncIterator[AgentEvent]:
+    async def stream(
+        self, context: AgentContext, text: str
+    ) -> AsyncIterator[AgentEvent]:
         params = _apply_dify_defaults(context)
         api_server = params.get("api_server")
         api_key = params.get("api_key")
@@ -78,7 +82,9 @@ class DifyAgentHandler(AgentHandler):
         inputs = _coerce_dify_inputs(params)
 
         if not api_server:
-            yield AgentEvent(event="error", data={"message": "Missing Dify API server."})
+            yield AgentEvent(
+                event="error", data={"message": "Missing Dify API server."}
+            )
             return
         if not api_key:
             yield AgentEvent(event="error", data={"message": "Missing Dify API key."})
@@ -134,7 +140,9 @@ class DifyAgentHandler(AgentHandler):
                     answer = data.get("answer")
                     event_name = data.get("event", "")
                     if answer and "message" in str(event_name):
-                        yield AgentEvent(event="message.delta", data={"text": str(answer)})
+                        yield AgentEvent(
+                            event="message.delta", data={"text": str(answer)}
+                        )
 
         yield AgentEvent(event="message.done", data={})
 
@@ -152,7 +160,9 @@ class CozeAgentHandler(AgentHandler):
             "Content-Type": "application/json",
         }
         headers.update(context.runtime.headers)
-        conversation_path = _resolve_path(context.runtime, "conversation", "/v1/conversation/create")
+        conversation_path = _resolve_path(
+            context.runtime, "conversation", "/v1/conversation/create"
+        )
         async with httpx.AsyncClient(timeout=context.runtime.timeout) as client:
             response = await client.post(
                 _build_url(api_base, conversation_path),
@@ -162,7 +172,9 @@ class CozeAgentHandler(AgentHandler):
             data = response.json()
         return str(data.get("data", {}).get("id") or "")
 
-    async def stream(self, context: AgentContext, text: str) -> AsyncIterator[AgentEvent]:
+    async def stream(
+        self, context: AgentContext, text: str
+    ) -> AsyncIterator[AgentEvent]:
         params = _apply_coze_defaults(context)
         api_base = params.get("api_base")
         token = params.get("token")
@@ -183,7 +195,9 @@ class CozeAgentHandler(AgentHandler):
         if not conversation_id:
             conversation_id = await self.create_conversation(context)
             if conversation_id:
-                yield AgentEvent(event="conversation.id", data={"conversation_id": conversation_id})
+                yield AgentEvent(
+                    event="conversation.id", data={"conversation_id": conversation_id}
+                )
 
         headers = {
             "Authorization": f"Bearer {token}",
@@ -210,7 +224,9 @@ class CozeAgentHandler(AgentHandler):
             api_url = f"{api_url}{separator}conversation_id={conversation_id}"
 
         async with httpx.AsyncClient(timeout=context.runtime.timeout) as client:
-            async with client.stream("POST", api_url, headers=headers, json=payload) as response:
+            async with client.stream(
+                "POST", api_url, headers=headers, json=payload
+            ) as response:
                 response.raise_for_status()
                 event_name: Optional[str] = None
                 async for line in response.aiter_lines():
@@ -233,10 +249,14 @@ class CozeAgentHandler(AgentHandler):
                         continue
                     reasoning_content = message_json.get("reasoning_content")
                     if reasoning_content:
-                        yield AgentEvent(event="message.think", data={"text": str(reasoning_content)})
+                        yield AgentEvent(
+                            event="message.think", data={"text": str(reasoning_content)}
+                        )
                     content = message_json.get("content")
                     if content:
-                        yield AgentEvent(event="message.delta", data={"text": str(content)})
+                        yield AgentEvent(
+                            event="message.delta", data={"text": str(content)}
+                        )
 
         yield AgentEvent(event="message.done", data={})
 
@@ -247,27 +267,31 @@ class FastGPTAgentHandler(AgentHandler):
         conversation_id = params.get("conversation_id")
         if conversation_id:
             return str(conversation_id)
-        return os.urandom(8).hex()
+        return ""
 
-    async def stream(self, context: AgentContext, text: str) -> AsyncIterator[AgentEvent]:
+    async def stream(
+        self, context: AgentContext, text: str
+    ) -> AsyncIterator[AgentEvent]:
         params = _apply_fastgpt_defaults(context)
         base_url = params.get("base_url")
         api_key = params.get("api_key")
         conversation_id = params.get("conversation_id") or ""
-        variables = _coerce_fastgpt_variables(params.get("variables"))
-        detail = params.get("detail", False)
+        variables = coerce_json_dict(params.get("variables"))
+        detail = coerce_bool(params.get("detail"), default=False)
 
         if not base_url:
-            yield AgentEvent(event="error", data={"message": "Missing FastGPT base URL."})
+            yield AgentEvent(
+                event="error", data={"message": "Missing FastGPT base URL."}
+            )
             return
         if not api_key:
-            yield AgentEvent(event="error", data={"message": "Missing FastGPT API key."})
+            yield AgentEvent(
+                event="error", data={"message": "Missing FastGPT API key."}
+            )
             return
 
         if not conversation_id:
             conversation_id = await self.create_conversation(context)
-            if conversation_id:
-                yield AgentEvent(event="conversation.id", data={"conversation_id": conversation_id})
 
         headers = {
             "Authorization": f"Bearer {api_key}",
@@ -277,7 +301,7 @@ class FastGPTAgentHandler(AgentHandler):
         payload = {
             "chatId": conversation_id,
             "stream": True,
-            "detail": bool(detail),
+            "detail": detail,
             "messages": [
                 {"role": "user", "content": text},
             ],
@@ -287,7 +311,9 @@ class FastGPTAgentHandler(AgentHandler):
 
         chat_path = _resolve_path(context.runtime, "chat", "/v1/chat/completions")
         async with httpx.AsyncClient(timeout=context.runtime.timeout) as client:
-            async with client.stream("POST", _build_url(base_url, chat_path), headers=headers, json=payload) as response:
+            async with client.stream(
+                "POST", _build_url(base_url, chat_path), headers=headers, json=payload
+            ) as response:
                 if response.status_code >= 400:
                     detail = await _read_error_detail(response)
                     yield AgentEvent(event="error", data={"message": detail})
@@ -316,7 +342,10 @@ class FastGPTAgentHandler(AgentHandler):
                         extracted_id = _extract_fastgpt_chat_id(data)
                         if extracted_id:
                             current_conversation_id = extracted_id
-                            yield AgentEvent(event="conversation.id", data={"conversation_id": extracted_id})
+                            yield AgentEvent(
+                                event="conversation.id",
+                                data={"conversation_id": extracted_id},
+                            )
 
                     event_type = current_event or "answer"
                     if event_type in ("answer", "fastAnswer"):
@@ -326,16 +355,23 @@ class FastGPTAgentHandler(AgentHandler):
                         except (KeyError, IndexError, TypeError):
                             content = None
                         if content:
-                            yield AgentEvent(event="message.delta", data={"text": str(content)})
+                            yield AgentEvent(
+                                event="message.delta", data={"text": str(content)}
+                            )
                     elif event_type == "error":
                         message = (
                             data.get("message") or data.get("error") or "Unknown error"
                         )
                         yield AgentEvent(event="error", data={"message": str(message)})
                     elif event_type == "interactive":
-                        yield AgentEvent(event="interactive", data={"interactive": data.get("interactive", {})})
+                        yield AgentEvent(
+                            event="interactive",
+                            data={"interactive": data.get("interactive", {})},
+                        )
                     elif event_type == "flowResponses":
-                        yield AgentEvent(event="flow_responses", data={"responses": data})
+                        yield AgentEvent(
+                            event="flow_responses", data={"responses": data}
+                        )
 
         yield AgentEvent(event="message.done", data={})
 
@@ -351,7 +387,9 @@ class CustomAgentHandler(AgentHandler):
         if not base_url:
             return ""
 
-        conversation_path = context.runtime.paths.get("conversation") if context.runtime.paths else None
+        conversation_path = (
+            context.runtime.paths.get("conversation") if context.runtime.paths else None
+        )
         if not conversation_path:
             return ""
 
@@ -366,11 +404,15 @@ class CustomAgentHandler(AgentHandler):
 
         return _extract_conversation_id(data)
 
-    async def stream(self, context: AgentContext, text: str) -> AsyncIterator[AgentEvent]:
+    async def stream(
+        self, context: AgentContext, text: str
+    ) -> AsyncIterator[AgentEvent]:
         params = _apply_custom_defaults(context)
         base_url = params.get("base_url")
         if not base_url:
-            yield AgentEvent(event="error", data={"message": "Missing custom agent base URL."})
+            yield AgentEvent(
+                event="error", data={"message": "Missing custom agent base URL."}
+            )
             return
 
         chat_path = _resolve_path(context.runtime, "chat", "/chat")
@@ -384,7 +426,9 @@ class CustomAgentHandler(AgentHandler):
         }
 
         async with httpx.AsyncClient(timeout=context.runtime.timeout) as client:
-            async with client.stream("POST", url, headers=headers, json=payload) as response:
+            async with client.stream(
+                "POST", url, headers=headers, json=payload
+            ) as response:
                 response.raise_for_status()
                 async for event in _stream_sse_events(response):
                     yield event
@@ -395,7 +439,9 @@ class CustomAgentHandler(AgentHandler):
 _HANDLER_REGISTRY: Dict[str, Type[AgentHandler]] = {}
 
 
-def register_agent_handler(engine_types: Iterable[str], handler: Type[AgentHandler]) -> None:
+def register_agent_handler(
+    engine_types: Iterable[str], handler: Type[AgentHandler]
+) -> None:
     for engine_type in engine_types:
         if not engine_type:
             continue
@@ -475,7 +521,9 @@ def _build_dify_url(base_url: str, path: str) -> str:
     return normalized_base + normalized_path
 
 
-def _build_headers(runtime: EngineRuntimeConfig, api_key: Optional[str]) -> Dict[str, str]:
+def _build_headers(
+    runtime: EngineRuntimeConfig, api_key: Optional[str]
+) -> Dict[str, str]:
     headers = {"Content-Type": "application/json"}
     headers.update(runtime.headers)
     if api_key:
@@ -499,18 +547,7 @@ def _coerce_dify_conversation_id(value: Any) -> str:
 
 
 def _coerce_dify_inputs(params: Dict[str, Any]) -> Dict[str, Any]:
-    inputs = params.get("inputs")
-    if inputs is None or inputs == "":
-        return {}
-    if isinstance(inputs, dict):
-        return inputs
-    if isinstance(inputs, str):
-        try:
-            parsed = json.loads(inputs)
-        except json.JSONDecodeError:
-            return {}
-        if isinstance(parsed, dict):
-            return parsed
+    return coerce_json_dict(params.get("inputs"))
     return {}
 
 
@@ -526,7 +563,9 @@ async def _read_error_detail(response: httpx.Response) -> str:
         except json.JSONDecodeError:
             return text
         if isinstance(payload, dict):
-            message = payload.get("message") or payload.get("detail") or payload.get("error")
+            message = (
+                payload.get("message") or payload.get("detail") or payload.get("error")
+            )
             code = payload.get("code")
             if message and code:
                 return f"{message} ({code})"
@@ -562,7 +601,9 @@ async def _stream_sse_events(response: httpx.Response) -> AsyncIterator[AgentEve
             yield event
 
 
-def _normalize_custom_event(event_name: Optional[str], payload_text: str) -> Optional[AgentEvent]:
+def _normalize_custom_event(
+    event_name: Optional[str], payload_text: str
+) -> Optional[AgentEvent]:
     name = (event_name or "").strip()
     data: Any = payload_text
     if payload_text:
@@ -571,7 +612,13 @@ def _normalize_custom_event(event_name: Optional[str], payload_text: str) -> Opt
         except json.JSONDecodeError:
             data = payload_text
 
-    if name in {"message.delta", "message.think", "message.done", "conversation.id", "error"}:
+    if name in {
+        "message.delta",
+        "message.think",
+        "message.done",
+        "conversation.id",
+        "error",
+    }:
         return _coerce_agent_event(name, data)
     if name in {"done", "message.done", "final"}:
         return AgentEvent(event="message.done", data={})
@@ -592,7 +639,11 @@ def _coerce_agent_event(event: str, data: Any) -> AgentEvent:
         return AgentEvent(event=event, data={"text": ""})
     if event == "conversation.id":
         if isinstance(data, dict):
-            conversation_id = data.get("conversation_id") or data.get("conversationId") or data.get("id")
+            conversation_id = (
+                data.get("conversation_id")
+                or data.get("conversationId")
+                or data.get("id")
+            )
             return AgentEvent(event=event, data={"conversation_id": conversation_id})
         if isinstance(data, str):
             return AgentEvent(event=event, data={"conversation_id": data})
@@ -634,21 +685,6 @@ def _extract_fastgpt_chat_id(data: Dict[str, Any]) -> Optional[str]:
             if isinstance(value, str) and value:
                 return value
     return None
-
-
-def _coerce_fastgpt_variables(value: Any) -> Dict[str, Any]:
-    """解析 FastGPT variables 参数"""
-    if value is None or value == "":
-        return {}
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-            return parsed if isinstance(parsed, dict) else {}
-        except json.JSONDecodeError:
-            return {}
-    return {}
 
 
 register_agent_handler({"dify", "dify_agent"}, DifyAgentHandler)

--- a/backend/app/services/agents/utils.py
+++ b/backend/app/services/agents/utils.py
@@ -30,3 +30,36 @@ def coerce_text(data: Any) -> str:
         if isinstance(text, str):
             return text
     return ""
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    """Safely coerce a value to boolean."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lower = value.lower().strip()
+        if lower in {"1", "true", "yes", "on"}:
+            return True
+        if lower in {"0", "false", "no", "off", ""}:
+            return False
+        return bool(value)
+    return default
+
+
+def coerce_json_dict(value: Any) -> Dict[str, Any]:
+    """Convert string/dict to dict, handling JSON strings."""
+    if value is None or value == "":
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}

--- a/backend/app/services/providers/llm.py
+++ b/backend/app/services/providers/llm.py
@@ -202,10 +202,9 @@ class DifyProvider(LLMProvider):
 
 
 class FastGPTProvider(LLMProvider):
-    def __init__(self, base_url: str, api_key: str, uid: str, timeout: float) -> None:
+    def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
-        self.uid = uid
         self.timeout = timeout
 
     async def generate(
@@ -227,7 +226,6 @@ class FastGPTProvider(LLMProvider):
             "messages": [
                 {"role": "user", "content": text},
             ],
-            "customUid": user_id or self.uid,
         }
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(f"{self.base_url}/v1/chat/completions", headers=headers, json=payload)
@@ -389,7 +387,6 @@ def build_llm_provider(settings: AppSettings) -> LLMProvider:
         return FastGPTProvider(
             base_url=settings.fastgpt_base_url,
             api_key=settings.fastgpt_api_key,
-            uid=settings.fastgpt_uid,
             timeout=settings.llm_timeout,
         )
     if provider == "coze":
@@ -436,11 +433,9 @@ def build_llm_provider_from_config(
             raise LLMConfigError("FastGPT base URL is required")
         if not config.api_key:
             raise LLMConfigError("FastGPT API key is required")
-        uid = config.extra.get("uid") if isinstance(config.extra, dict) else None
         return FastGPTProvider(
             base_url=config.base_url,
             api_key=config.api_key,
-            uid=uid or settings.fastgpt_uid,
             timeout=settings.llm_timeout,
         )
 

--- a/backend/config/engines.yaml
+++ b/backend/config/engines.yaml
@@ -306,18 +306,21 @@ agent:
       api_key_env: FASTGPT_API_KEY
       paths:
         chat: /v1/chat/completions
-        health: /health
       defaults:
-        uid: whale
+        detail: false
       params:
         - name: base_url
           type: string
           default: https://cloud.fastgpt.cn/api
         - name: api_key
           type: secret
-        - name: uid
+        - name: variables
           type: string
-          default: whale
+          description: JSON object for app input variables, e.g. {"user_name":"小明"}
+        - name: detail
+          type: boolean
+          default: false
+          description: Return detailed response including sources and metadata
     - id: custom-agent
       label: Custom Agent
       type: custom_agent

--- a/frontend/packages/app-core/src/stores/chat.ts
+++ b/frontend/packages/app-core/src/stores/chat.ts
@@ -385,6 +385,18 @@ function prepareOutgoingMessage(
       pushMessage({ role: "error", content: payload.message || rawText || "Agent error." });
       return;
     }
+
+    if (event.event === "interactive") {
+      // FastGPT interactive node - currently just log, future UI handling possible
+      console.log("[Agent] Interactive event:", payload.interactive || payload);
+      return;
+    }
+
+    if (event.event === "flow_responses" || event.event === "flowResponses") {
+      // FastGPT flow responses - currently just log, future UI handling possible
+      console.log("[Agent] Flow responses:", payload.responses || payload);
+      return;
+    }
   }
 
   function sanitizeAgentConfig(config: Record<string, unknown>) {


### PR DESCRIPTION
## 背景

PR #37「feat(fastgpt): 增强 FastGPT 智能体对接」原误合并到 **main** 分支（已通过 PR #47 revert 撤回）。本 PR 将相同的改动正确合入 **dev** 开发分支。

dev 分支 3 个月来独立演进，本 PR 已验证可与 dev 现有代码干净合并。

## 改动

Cherry-pick 自 PR #37 两个内容提交（原作者 @chaojixinren 署名保留）：

1. \`8b0b3bb\` feat(fastgpt)：增强 FastGPT 对接
   - 新增 variables / detail 参数支持
   - 改进 SSE 事件解析（支持 event: 行、answer/fastAnswer/error/interactive/flowResponses）
   - 新增 HTTP 错误状态码处理、自动提取 conversation.id
2. \`65d3458\` refactor(agent)：coerce_bool 重构 + handlers stream 方法重构 + interactive/flow 响应日志
3. \`37b4dcd\` chore：补 \`.env\` 忽略规则（PR#37 原 .gitignore 改动，cherry-pick 冲突时取 dev 版丢失，在此补回，与 main 侧 revert 保留 .env 保持一致）

## 验证（关键）

- **cherry-pick 业务文件零冲突**：PR#37 改动行与 dev 3 个月独立演进的行不重叠，git 三方合并自动处理（仅 .gitignore 一个非业务冲突）
- \`py_compile\` agent/handlers/utils/llm → OK
- \`ruff --select F401\` → 无新增未使用 import（3 个 F401 为 dev 原有，属 PR #40 待清理范围）
- \`pytest tests/\` → **29 passed**
- \`python-dotenv\` 等依赖 dev 已具备

## 关联

- 撤回误合并：#47（Revert PR #37 on main）
- 同批：#45（Revert PR #38）/ #46（coze 进 dev）