### PR TITLE
refactor(backend): dedupe engine loader + add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .claude/
+.ccg/
 
 # Node/Electron
 node_modules/

--- a/backend/app/services/engines/loader.py
+++ b/backend/app/services/engines/loader.py
@@ -11,10 +11,10 @@ def bootstrap_engines() -> None:
     config = _load_engine_config()
     if not config:
         return
-    _load_llm_engines(config.get("llm") or {})
-    _load_tts_engines(config.get("tts") or {})
-    _load_asr_engines(config.get("asr") or {})
-    _load_agent_engines(config.get("agent") or {})
+    _load_engines("llm", config.get("llm") or {})
+    _load_engines("tts", config.get("tts") or {})
+    _load_engines("asr", config.get("asr") or {})
+    _load_engines("agent", config.get("agent") or {}, default_type="agent")
 
 
 def _load_engine_config() -> Dict[str, Any]:
@@ -34,7 +34,11 @@ def _load_engine_config() -> Dict[str, Any]:
     return data
 
 
-def _load_llm_engines(config: Dict[str, Any]) -> None:
+def _load_engines(
+    kind: str,
+    config: Dict[str, Any],
+    default_type: str = "openai_compat",
+) -> None:
     default_id = _as_str(config.get("default"))
     engines = config.get("engines")
     if not isinstance(engines, list):
@@ -50,7 +54,7 @@ def _load_llm_engines(config: Dict[str, Any]) -> None:
 
         label = _as_str(engine.get("label")) or engine_id
         description = _as_str(engine.get("description"))
-        engine_type = _as_str(engine.get("type")) or "openai_compat"
+        engine_type = _as_str(engine.get("type")) or default_type
         metadata = _parse_metadata(engine, engine_type)
 
         params = _parse_params(engine.get("params"))
@@ -61,7 +65,7 @@ def _load_llm_engines(config: Dict[str, Any]) -> None:
             params=params,
             metadata=metadata,
         )
-        registry.register("llm", spec, default=engine_id == default_id or index == 0)
+        registry.register(kind, spec, default=engine_id == default_id or index == 0)
 
         base_url = _as_str(engine.get("base_url") or engine.get("baseUrl") or "")
         model = _as_str(engine.get("model") or "")
@@ -71,166 +75,11 @@ def _load_llm_engines(config: Dict[str, Any]) -> None:
         default_params = _parse_defaults(engine, params)
 
         runtime_store.register(
-            "llm",
+            kind,
             EngineRuntimeConfig(
                 id=engine_id,
                 base_url=base_url,
                 model=model,
-                api_key_env=api_key_env or None,
-                headers={str(k): str(v) for k, v in headers.items()},
-                timeout=timeout,
-                default_params=default_params,
-                engine_type=engine_type,
-                paths=_parse_paths(engine.get("paths")),
-            ),
-        )
-
-
-def _load_tts_engines(config: Dict[str, Any]) -> None:
-    default_id = _as_str(config.get("default"))
-    engines = config.get("engines")
-    if not isinstance(engines, list):
-        return
-
-    for index, engine in enumerate(engines):
-        if not isinstance(engine, dict):
-            continue
-
-        engine_id = _as_str(engine.get("id"))
-        if not engine_id:
-            continue
-
-        label = _as_str(engine.get("label")) or engine_id
-        description = _as_str(engine.get("description"))
-        engine_type = _as_str(engine.get("type")) or "openai_compat"
-        metadata = _parse_metadata(engine, engine_type)
-
-        params = _parse_params(engine.get("params"))
-        spec = EngineSpec(
-            id=engine_id,
-            label=label,
-            description=description,
-            params=params,
-            metadata=metadata,
-        )
-        registry.register("tts", spec, default=engine_id == default_id or index == 0)
-
-        base_url = _as_str(engine.get("base_url") or engine.get("baseUrl") or "")
-        model = _as_str(engine.get("model") or "")
-        api_key_env = _as_str(engine.get("api_key_env") or engine.get("apiKeyEnv"))
-        headers = engine.get("headers") if isinstance(engine.get("headers"), dict) else {}
-        timeout = _as_float(engine.get("timeout"), 60.0)
-        default_params = _parse_defaults(engine, params)
-
-        runtime_store.register(
-            "tts",
-            EngineRuntimeConfig(
-                id=engine_id,
-                base_url=base_url,
-                model=model,
-                api_key_env=api_key_env or None,
-                headers={str(k): str(v) for k, v in headers.items()},
-                timeout=timeout,
-                default_params=default_params,
-                engine_type=engine_type,
-                paths=_parse_paths(engine.get("paths")),
-            ),
-        )
-
-
-def _load_asr_engines(config: Dict[str, Any]) -> None:
-    default_id = _as_str(config.get("default"))
-    engines = config.get("engines")
-    if not isinstance(engines, list):
-        return
-
-    for index, engine in enumerate(engines):
-        if not isinstance(engine, dict):
-            continue
-
-        engine_id = _as_str(engine.get("id"))
-        if not engine_id:
-            continue
-
-        label = _as_str(engine.get("label")) or engine_id
-        description = _as_str(engine.get("description"))
-        engine_type = _as_str(engine.get("type")) or "openai_compat"
-        metadata = _parse_metadata(engine, engine_type)
-
-        params = _parse_params(engine.get("params"))
-        spec = EngineSpec(
-            id=engine_id,
-            label=label,
-            description=description,
-            params=params,
-            metadata=metadata,
-        )
-        registry.register("asr", spec, default=engine_id == default_id or index == 0)
-
-        base_url = _as_str(engine.get("base_url") or engine.get("baseUrl") or "")
-        model = _as_str(engine.get("model") or "")
-        api_key_env = _as_str(engine.get("api_key_env") or engine.get("apiKeyEnv"))
-        headers = engine.get("headers") if isinstance(engine.get("headers"), dict) else {}
-        timeout = _as_float(engine.get("timeout"), 60.0)
-        default_params = _parse_defaults(engine, params)
-
-        runtime_store.register(
-            "asr",
-            EngineRuntimeConfig(
-                id=engine_id,
-                base_url=base_url,
-                model=model,
-                api_key_env=api_key_env or None,
-                headers={str(k): str(v) for k, v in headers.items()},
-                timeout=timeout,
-                default_params=default_params,
-                engine_type=engine_type,
-                paths=_parse_paths(engine.get("paths")),
-            ),
-        )
-
-
-def _load_agent_engines(config: Dict[str, Any]) -> None:
-    default_id = _as_str(config.get("default"))
-    engines = config.get("engines")
-    if not isinstance(engines, list):
-        return
-
-    for index, engine in enumerate(engines):
-        if not isinstance(engine, dict):
-            continue
-
-        engine_id = _as_str(engine.get("id"))
-        if not engine_id:
-            continue
-
-        label = _as_str(engine.get("label")) or engine_id
-        description = _as_str(engine.get("description"))
-        engine_type = _as_str(engine.get("type")) or "agent"
-        metadata = _parse_metadata(engine, engine_type)
-
-        params = _parse_params(engine.get("params"))
-        spec = EngineSpec(
-            id=engine_id,
-            label=label,
-            description=description,
-            params=params,
-            metadata=metadata,
-        )
-        registry.register("agent", spec, default=engine_id == default_id or index == 0)
-
-        base_url = _as_str(engine.get("base_url") or engine.get("baseUrl") or "")
-        api_key_env = _as_str(engine.get("api_key_env") or engine.get("apiKeyEnv"))
-        headers = engine.get("headers") if isinstance(engine.get("headers"), dict) else {}
-        timeout = _as_float(engine.get("timeout"), 60.0)
-        default_params = _parse_defaults(engine, params)
-
-        runtime_store.register(
-            "agent",
-            EngineRuntimeConfig(
-                id=engine_id,
-                base_url=base_url,
-                model=_as_str(engine.get("model") or ""),
                 api_key_env=api_key_env or None,
                 headers={str(k): str(v) for k, v in headers.items()},
                 timeout=timeout,

--- a/backend/tests/test_engine_loader.py
+++ b/backend/tests/test_engine_loader.py
@@ -1,0 +1,125 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from app.services.engines import registry, runtime_store  # noqa: E402
+from app.services.engines.loader import _load_engines  # noqa: E402
+
+
+def run(name: str, fn):
+    try:
+        fn()
+        print(f"PASS {name}")
+    except Exception:
+        print(f"FAIL {name}")
+        raise
+
+
+def _reset_registry():
+    for kind in ("llm", "tts", "asr", "agent"):
+        registry._engines[kind] = {}
+        registry._defaults[kind] = None
+
+
+def _sample_config(engine_id: str = "test-engine"):
+    return {
+        "default": engine_id,
+        "engines": [
+            {
+                "id": engine_id,
+                "label": "Test Engine",
+                "description": "desc",
+                "type": "openai_compat",
+                "base_url": "https://example.com",
+                "model": "gpt-test",
+                "api_key_env": "TEST_KEY",
+                "headers": {"X-Custom": "1"},
+                "timeout": 30,
+                "params": [{"name": "temperature", "type": "number", "default": 0.7}],
+                "defaults": {"user": "whale"},
+                "paths": {"chat": "/v1/chat"},
+            }
+        ],
+    }
+
+
+def test_load_llm_engine_registers_spec_and_runtime():
+    _reset_registry()
+    _load_engines("llm", _sample_config("llm-1"))
+
+    default_spec = registry.get_default("llm")
+    assert default_spec is not None
+    assert default_spec.id == "llm-1"
+    assert default_spec.label == "Test Engine"
+    assert default_spec.description == "desc"
+
+    runtime = runtime_store.get("llm", "llm-1")
+    assert runtime is not None
+    assert runtime.base_url == "https://example.com"
+    assert runtime.model == "gpt-test"
+    assert runtime.api_key_env == "TEST_KEY"
+    assert runtime.timeout == 30.0
+    assert runtime.headers == {"X-Custom": "1"}
+    assert runtime.default_params == {"user": "whale", "temperature": 0.7}
+    assert runtime.paths == {"chat": "/v1/chat"}
+
+
+def test_load_agent_engine_defaults_to_agent_type():
+    _reset_registry()
+    # agent config without explicit "type" should fall back to "agent"
+    config = {
+        "engines": [{"id": "agent-1", "base_url": "https://agent.example.com"}],
+    }
+    _load_engines("agent", config, default_type="agent")
+
+    runtime = runtime_store.get("agent", "agent-1")
+    assert runtime is not None
+    assert runtime.engine_type == "agent"
+    spec = registry.get("agent", "agent-1")
+    assert spec is not None
+    assert spec.metadata["type"] == "agent"
+
+
+def test_load_engine_first_becomes_default_without_explicit_default():
+    _reset_registry()
+    config = {
+        "engines": [
+            {"id": "first", "type": "openai_compat"},
+            {"id": "second", "type": "openai_compat"},
+        ],
+    }
+    _load_engines("tts", config)
+
+    assert registry.get_default("tts").id == "first"
+
+
+def test_load_engines_skips_invalid_entries():
+    _reset_registry()
+    config = {
+        "engines": [
+            "not-a-dict",
+            {"id": "", "type": "openai_compat"},  # missing id, skipped
+            {"id": "valid", "type": "openai_compat"},
+        ],
+    }
+    _load_engines("asr", config)
+
+    assert registry.get("asr", "valid") is not None
+    assert registry.get("asr", "") is None
+
+
+def test_load_engines_noop_when_engines_not_list():
+    _reset_registry()
+    _load_engines("llm", {"default": "x", "engines": "not-a-list"})
+    assert registry.get_default("llm") is None
+
+
+if __name__ == "__main__":
+    run("load llm engine registers spec and runtime", test_load_llm_engine_registers_spec_and_runtime)
+    run("load agent engine defaults to agent type", test_load_agent_engine_defaults_to_agent_type)
+    run("load engine first becomes default without explicit default", test_load_engine_first_becomes_default_without_explicit_default)
+    run("load engines skips invalid entries", test_load_engines_skips_invalid_entries)
+    run("load engines noop when engines not list", test_load_engines_noop_when_engines_not_list)


### PR DESCRIPTION
## 背景

多模型冗余代码审计（codex reviewer）发现 \`services/engines/loader.py\` 四套 \`_load_*_engines\` 函数高度重复（各 ~50 行几乎同构）。

## 改动

**重构 \`loader.py\`**（-163 行重复 / +12 行公共函数）
- 合并 \`_load_llm_engines\` / \`_load_tts_engines\` / \`_load_asr_engines\` / \`_load_agent_engines\` 为单一 \`_load_engines(kind, config, default_type=\"openai_compat\")\`
- agent 通过 \`default_type=\"agent\"\` 参数保留其默认类型差异
- model 读取统一（agent 原本内联读取 \`engine.get(\"model\")\`，现与其它一致，行为不变）

**新增 \`tests/test_engine_loader.py\`**（+125 行）
- loader 此前**零测试覆盖**，重构前先补测试保障行为等价
- 覆盖：spec/runtime 注册、agent 默认类型、首项成为 default、跳过无效条目、非 list 输入 noop

**\`.gitignore\`**：忽略 \`.ccg/\` 本地任务目录

## 验证

- \`py_compile\` → OK
- \`ruff --select F401,F811,F821\` → All checks passed
- \`pytest tests/\` → **33 passed**（原 28 + 新 5 loader 测试）

重构行为等价，由新增测试覆盖保障。

## 关联

冗余代码审计第二批重构 PR-1。后续候选：engine 路由共享 helper、schema from_spec() 转换。