### PR TITLE
refactor(backend): add ProviderDesc from_spec to dedupe catalog mapping

### DIFF
--- a/backend/app/api/provider_catalog_schemas.py
+++ b/backend/app/api/provider_catalog_schemas.py
@@ -9,6 +9,15 @@ class ProviderFieldOption(BaseModel):
     description: Optional[str] = None
     icon: Optional[str] = None
 
+    @classmethod
+    def from_spec(cls, spec) -> "ProviderFieldOption":
+        return cls(
+            id=spec.id,
+            label=spec.label,
+            description=spec.description,
+            icon=spec.icon,
+        )
+
 
 class ProviderField(BaseModel):
     id: str
@@ -25,6 +34,21 @@ class ProviderField(BaseModel):
     class Config:
         populate_by_name = True
 
+    @classmethod
+    def from_spec(cls, spec) -> "ProviderField":
+        return cls(
+            id=spec.id,
+            label=spec.label,
+            field_type=spec.field_type,
+            required=spec.required,
+            placeholder=spec.placeholder,
+            default=spec.default,
+            description=spec.description,
+            scope=spec.scope,
+            options=[ProviderFieldOption.from_spec(o) for o in spec.options],
+            options_source=spec.options_source,
+        )
+
 
 class ProviderDefaults(BaseModel):
     base_url: Optional[str] = Field(default=None, alias="baseUrl")
@@ -33,6 +57,14 @@ class ProviderDefaults(BaseModel):
 
     class Config:
         populate_by_name = True
+
+    @classmethod
+    def from_spec(cls, spec) -> "ProviderDefaults":
+        return cls(
+            base_url=spec.base_url,
+            model=spec.model,
+            voice=spec.voice,
+        )
 
 
 class ProviderDesc(BaseModel):
@@ -47,6 +79,19 @@ class ProviderDesc(BaseModel):
 
     class Config:
         populate_by_name = True
+
+    @classmethod
+    def from_spec(cls, spec, fields: Optional[List["ProviderField"]] = None) -> "ProviderDesc":
+        return cls(
+            id=spec.id,
+            label=spec.label,
+            category=spec.category,
+            icon=spec.icon,
+            description=spec.description,
+            engine_id=spec.engine_id,
+            defaults=ProviderDefaults.from_spec(spec.defaults) if spec.defaults else None,
+            fields=fields if fields is not None else [ProviderField.from_spec(f) for f in spec.fields],
+        )
 
 
 class ProviderCatalogResponse(BaseModel):

--- a/backend/app/api/providers.py
+++ b/backend/app/api/providers.py
@@ -3,7 +3,11 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
-from app.api.provider_catalog_schemas import ProviderCatalogResponse, ProviderDesc
+from app.api.provider_catalog_schemas import (
+    ProviderCatalogResponse,
+    ProviderDesc,
+    ProviderField,
+)
 from app.services.providers.registry import registry
 from app.services.providers.types import ProviderConfig
 from app.services.catalogs.provider_catalog import get_provider_catalog
@@ -37,53 +41,24 @@ class ProviderVoicesResponse(BaseModel):
     voices: List[Dict[str, Any]] = Field(default_factory=list)
 
 
-def _provider_field_to_dict(field) -> Dict[str, Any]:
-    return {
-        "id": field.id,
-        "label": field.label,
-        "type": field.field_type,
-        "required": field.required,
-        "placeholder": field.placeholder,
-        "default": field.default,
-        "description": field.description,
-        "scope": field.scope,
-        "options": [
-            {
-                "id": option.id,
-                "label": option.label,
-                "description": option.description,
-                "icon": option.icon,
-            }
-            for option in field.options
-        ],
-        "optionsSource": field.options_source,
-    }
-
-
-def _aliyun_nls_default_field_dicts() -> List[Dict[str, Any]]:
+def _aliyun_nls_default_fields() -> List[ProviderField]:
     return [
-        {
-            "id": "apiKey",
-            "label": "API Key",
-            "type": "secret",
-            "required": True,
-            "placeholder": None,
-            "default": None,
-            "description": None,
-            "scope": "config",
-            "options": [],
-            "optionsSource": None,
-        },
+        ProviderField(
+            id="apiKey",
+            label="API Key",
+            field_type="secret",
+            required=True,
+        ),
     ]
 
 
-def _resolve_provider_field_dicts(spec) -> List[Dict[str, Any]]:
-    fields = [_provider_field_to_dict(field) for field in spec.fields]
+def _resolve_provider_fields(spec) -> List[ProviderField]:
+    fields = [ProviderField.from_spec(field) for field in spec.fields]
     if spec.id != ALIYUN_NLS_PROVIDER_ID:
         return fields
 
     # Keep UI minimal for this provider: only API key is exposed.
-    return _aliyun_nls_default_field_dicts()
+    return _aliyun_nls_default_fields()
 
 
 def _to_config(request: ProviderRequest) -> ProviderConfig:
@@ -121,22 +96,7 @@ async def list_voices(request: ProviderRequest) -> ProviderVoicesResponse:
 async def list_provider_catalog() -> ProviderCatalogResponse:
     catalog = get_provider_catalog()
     providers = [
-        ProviderDesc(
-            id=spec.id,
-            label=spec.label,
-            category=spec.category,
-            icon=spec.icon,
-            description=spec.description,
-            engineId=spec.engine_id,
-            defaults={
-                "baseUrl": spec.defaults.base_url,
-                "model": spec.defaults.model,
-                "voice": spec.defaults.voice,
-            }
-            if spec.defaults
-            else None,
-            fields=_resolve_provider_field_dicts(spec),
-        )
+        ProviderDesc.from_spec(spec, fields=_resolve_provider_fields(spec))
         for spec in catalog.list()
     ]
     return ProviderCatalogResponse(providers=providers)

--- a/backend/tests/test_provider_catalog_aliyun_fields.py
+++ b/backend/tests/test_provider_catalog_aliyun_fields.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
-from app.api.providers import _resolve_provider_field_dicts
+from app.api.providers import _resolve_provider_fields
 from app.services.catalogs.provider_catalog import ProviderFieldSpec, ProviderSpec
 
 
@@ -39,8 +39,8 @@ def test_aliyun_catalog_fields_are_normalized_when_openai_style_fields_present()
         ],
     )
 
-    fields = _resolve_provider_field_dicts(spec)
-    field_ids = [item["id"] for item in fields]
+    fields = _resolve_provider_fields(spec)
+    field_ids = [item.id for item in fields]
 
     assert field_ids == ["apiKey"]
     assert "baseUrl" not in field_ids
@@ -59,8 +59,8 @@ def test_aliyun_catalog_fields_are_forced_to_minimal_shape():
         ],
     )
 
-    fields = _resolve_provider_field_dicts(spec)
-    field_ids = [item["id"] for item in fields]
+    fields = _resolve_provider_fields(spec)
+    field_ids = [item.id for item in fields]
 
     assert field_ids == ["apiKey"]
 

--- a/backend/tests/test_provider_catalog_dto_contract.py
+++ b/backend/tests/test_provider_catalog_dto_contract.py
@@ -1,0 +1,112 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from app.api.providers import list_provider_catalog  # noqa: E402
+from app.services.catalogs.provider_catalog import (  # noqa: E402
+    ProviderFieldOptionSpec,
+    ProviderFieldSpec,
+    ProviderSpec,
+)
+from app.services.catalogs.provider_catalog import ProviderDefaults  # noqa: E402
+
+
+def run(name: str, fn):
+    try:
+        fn()
+        print(f"PASS {name}")
+    except Exception:
+        print(f"FAIL {name}")
+        raise
+
+
+def _spec_with_full_fields() -> ProviderSpec:
+    return ProviderSpec(
+        id="test-provider",
+        label="Test Provider",
+        category="llm",
+        icon="icon-x",
+        description="desc",
+        engine_id="engine-1",
+        defaults=ProviderDefaults(
+            base_url="https://example.com",
+            model="m1",
+            voice="v1",
+        ),
+        fields=[
+            ProviderFieldSpec(
+                id="model",
+                label="Model",
+                field_type="select",
+                required=True,
+                placeholder="pick",
+                default="m1",
+                description="model desc",
+                scope="config",
+                options=[
+                    ProviderFieldOptionSpec(
+                        id="m1", label="M1", description="opt", icon="i"
+                    )
+                ],
+                options_source="catalog",
+            )
+        ],
+    )
+
+
+def test_catalog_response_serializes_with_alias_contract():
+    """Freeze the API JSON contract: alias fields (engineId, baseUrl,
+    optionsSource, type) must appear in serialized output."""
+    import asyncio
+
+    import app.api.providers as providers_mod
+
+    original = providers_mod.get_provider_catalog
+    fake_spec = _spec_with_full_fields()
+
+    class _FakeCatalog:
+        def list(self):
+            return [fake_spec]
+
+    providers_mod.get_provider_catalog = lambda: _FakeCatalog()
+    try:
+        response = asyncio.run(list_provider_catalog())
+    finally:
+        providers_mod.get_provider_catalog = original
+
+    providers_list = response.providers
+    assert len(providers_list) == 1
+    desc = providers_list[0]
+
+    # top-level alias contract
+    dumped = desc.model_dump(by_alias=True, exclude_none=False)
+    assert dumped["engineId"] == "engine-1"
+    assert dumped["id"] == "test-provider"
+    assert dumped["category"] == "llm"
+
+    # defaults alias contract
+    assert dumped["defaults"]["baseUrl"] == "https://example.com"
+    assert dumped["defaults"]["model"] == "m1"
+    assert dumped["defaults"]["voice"] == "v1"
+
+    # field alias contract
+    field = dumped["fields"][0]
+    assert field["type"] == "select"
+    assert field["optionsSource"] == "catalog"
+    assert field["scope"] == "config"
+
+    # option contract
+    option = field["options"][0]
+    assert option["id"] == "m1"
+    assert option["label"] == "M1"
+    assert option["icon"] == "i"
+
+
+if __name__ == "__main__":
+    run(
+        "catalog response serializes with alias contract",
+        test_catalog_response_serializes_with_alias_contract,
+    )


### PR DESCRIPTION
## 背景

多模型冗余代码审计发现 \`api/providers.py\` 的 \`list_provider_catalog()\` 手写映射 \`ProviderSpec\` 每个字段到 DTO，外加并行的 \`_provider_field_to_dict\` 把同样字段重建为裸 dict。spec 字段变更时三处需同步。

## 改动

**\`provider_catalog_schemas.py\`**（+45）
- 为 \`ProviderFieldOption\` / \`ProviderField\` / \`ProviderDefaults\` / \`ProviderDesc\` 各加 \`from_spec(spec)\` 类方法，统一 spec→DTO 转换

**\`providers.py\`**（-61 重构）
- 删除 \`_provider_field_to_dict\` + \`_aliyun_nls_default_field_dicts\` + 内联 \`ProviderDesc(...)\` 手写映射
- 改用 \`_resolve_provider_fields\`（返回 \`ProviderField\` model）+ \`ProviderDesc.from_spec(spec, fields=...)\`
- aliyun NLS 最小字段特例保留（仅暴露 apiKey）

**测试**
- 新增 \`test_provider_catalog_dto_contract.py\`：**固化 API JSON alias 契约**（engineId/baseUrl/optionsSource/type），证明 from_spec 重构未改变序列化输出
- 更新 \`test_provider_catalog_aliyun_fields.py\` 适配新返回类型（dict → model 属性访问）

## 验证

- \`py_compile\` → OK
- \`ruff --select F401,F811,F821,F841\` → All checks passed
- \`pytest tests/\` → **29 passed**（含新契约测试 + 适配后 aliyun 测试）
- 契约测试通过证明 \`/providers/catalog\` 的 JSON 输出形态未变

## 关联

冗余代码审计第二批重构 PR-2。前序：#49（loader 抽公共函数）。剩余候选：engine 路由共享 helper。